### PR TITLE
Add myself to contributors

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -17,5 +17,12 @@
       "art"
     ],
     "url": "https://cookicons.co/"
+  },
+  {
+    "nick": "zaeleus",
+    "eth": "0xB98e578BB98AaE413314FF31D30EE1C9bcF7f708",
+    "role": [
+      "code"
+    ]
   }
 ]


### PR DESCRIPTION
Just to confirm, the eth addresses in `contributors.json` are Rinkeby testnet addresses?