### PR TITLE
Remove '.' in etherscan URL in case of mainnet.

### DIFF
--- a/app/src/main/java/org/walleth/data/blockexplorer/EtherscanBlockExplorer.kt
+++ b/app/src/main/java/org/walleth/data/blockexplorer/EtherscanBlockExplorer.kt
@@ -5,7 +5,7 @@ import org.kethereum.model.Address
 class EtherscanBlockExplorer(private val prefix: String) {
 
     val baseAPIURL by lazy { "https://" + (if (prefix.isBlank()) "api" else prefix) + ".etherscan.io/" }
-    private val baseURL by lazy { "https://$prefix.etherscan.io/" }
+    private val baseURL by lazy { "https://" + (if (prefix.isBlank()) "" else (prefix + ".")) + "etherscan.io/" }
 
     fun getURLforAddress(address: Address) = "$baseURL/address/${address.hex}"
     fun getURLforTransaction(transactionHash: String) = "$baseURL/tx/$transactionHash"


### PR DESCRIPTION
The mainnet uses an empty prefix for etherscan, which would result
in a URL of "https://.etherscan.io" if not handled specially.

--

This is my first ever piece of kotlin code. I have no idea whether it works - I could not find any build instructions.