### PR TITLE
Rounding

### DIFF
--- a/app/src/main/java/org/walleth/data/exchangerate/BaseExchangeProvider.kt
+++ b/app/src/main/java/org/walleth/data/exchangerate/BaseExchangeProvider.kt
@@ -21,8 +21,8 @@ abstract class BaseExchangeProvider : ExchangeRateProvider {
     } else {
         val exchangeRate = getExChangeRate(currencySymbol)!!
         val divided = BigDecimal(value).divide(BigDecimal(ETH_IN_WEI))
-        val times = exchangeRate.times(divided)
-        if (times.scale() in 0..2) {
+        val times = exchangeRate.times(divided).stripTrailingZeros()
+        if (times.scale() <= 2) {
             String.format("%.2f", times)
         } else {
             String.format("~%.2f", times)

--- a/app/src/main/java/org/walleth/functions/Formatting.kt
+++ b/app/src/main/java/org/walleth/functions/Formatting.kt
@@ -3,8 +3,12 @@ package org.walleth.functions
 import org.walleth.data.tokens.Token
 import java.math.BigDecimal
 import java.math.BigInteger
-import java.math.MathContext
-import java.math.RoundingMode
+import java.text.DecimalFormat
+
+val formatter: DecimalFormat
+    get() = DecimalFormat("#.#####")
+val roundingFormatter: DecimalFormat
+    get() = DecimalFormat("~#.#####")
 
 fun Token.decimalsInZeroes() = "0".repeat (decimals)
 fun Token.decimalsAsMultiplicator() = BigDecimal("1"+this.decimalsInZeroes())
@@ -12,6 +16,10 @@ fun Token.decimalsAsMultiplicator() = BigDecimal("1"+this.decimalsInZeroes())
 fun BigInteger.toValueString(token: Token) = BigDecimal(this).toValueString(token)
 
 fun BigDecimal.toValueString(token: Token): String {
-    val inEther = divide(BigDecimal("1" + token.decimalsInZeroes()))
-    return inEther.round(MathContext(6, RoundingMode.FLOOR)).stripTrailingZeros().toPlainString()
+    val inEther = divide(BigDecimal("1" + token.decimalsInZeroes())).stripTrailingZeros()
+    if (inEther.scale() < 6) {
+        return formatter.format(inEther)
+    } else {
+        return roundingFormatter.format(inEther)
+    }
 }

--- a/app/src/test/java/TheBaseExchangeProvider.kt
+++ b/app/src/test/java/TheBaseExchangeProvider.kt
@@ -1,0 +1,31 @@
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.walleth.data.ETH_IN_WEI
+import org.walleth.data.exchangerate.BaseExchangeProvider
+import java.math.BigDecimal
+import java.math.BigInteger
+
+class TheBaseExchangeProvider {
+
+    @Test
+    fun testExchangeStringWithTrailingZeros() {
+        val baseExchangeProvider = object : BaseExchangeProvider() {
+            override fun getExChangeRate(name: String) = BigDecimal("0.100")
+        }
+
+        assertThat(baseExchangeProvider.getExchangeString(BigInteger("2").times(ETH_IN_WEI), "USD"))
+                .isAnyOf("0,20", "0.20")
+        assertThat(baseExchangeProvider.getExchangeString(BigInteger("2000").times(ETH_IN_WEI), "USD"))
+                .isAnyOf("200,00", "200.00")
+    }
+
+    @Test
+    fun testExchangeStringWithRounding() {
+        val baseExchangeProvider = object : BaseExchangeProvider() {
+            override fun getExChangeRate(name: String) = BigDecimal("1")
+        }
+        val value = BigInteger("201").times(ETH_IN_WEI).divide(BigInteger("1000")) // 0.201 ETH
+        assertThat(baseExchangeProvider.getExchangeString(value, "USD"))
+                .isAnyOf("~0,20", "~0.20")
+    }
+}

--- a/app/src/test/java/TheFormatting.kt
+++ b/app/src/test/java/TheFormatting.kt
@@ -2,6 +2,8 @@ import com.google.common.truth.Truth.assertThat
 import data.testToken
 import org.junit.Test
 import org.walleth.functions.decimalsInZeroes
+import org.walleth.functions.toValueString
+import java.math.BigDecimal
 
 class TheFormatting {
 
@@ -10,7 +12,18 @@ class TheFormatting {
         assertThat(testToken.copy(decimals = 0).decimalsInZeroes()).isEqualTo("")
         assertThat(testToken.copy(decimals = 2).decimalsInZeroes()).isEqualTo("00")
         assertThat(testToken.copy(decimals = 8).decimalsInZeroes()).isEqualTo("00000000")
+    }
 
+    @Test
+    fun testWeDoNotRoundWithTrailingZeros() {
+        assertThat(BigDecimal("1.0000000").toValueString(testToken.copy(decimals = 0))).isEqualTo("1")
+        assertThat(BigDecimal("10.000000").toValueString(testToken.copy(decimals = 1))).isEqualTo("1")
+    }
+
+    @Test
+    fun testWeCanRound() {
+        assertThat(BigDecimal("2").toValueString(testToken.copy(decimals = 5))).isAnyOf("0.00002", "0,00002")
+        assertThat(BigDecimal("2").toValueString(testToken.copy(decimals = 6))).isEqualTo("~0")
     }
 
 }


### PR DESCRIPTION
Prefix eth value with ~ when scale > 5
Rounding creates a big integer with scale <= 5, ignore trailing zeros before calculating scale.

Fix rounding of fiat currency for big integers like 200 (was shown as ~200.00)

see #76 