### PR TITLE
90/Update transactions on fiat change

### DIFF
--- a/app/src/main/java/org/walleth/data/config/KotprefSettings.kt
+++ b/app/src/main/java/org/walleth/data/config/KotprefSettings.kt
@@ -1,5 +1,6 @@
 package org.walleth.data.config
 
+import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import android.support.v7.app.AppCompatDelegate
 import com.chibatching.kotpref.KotprefModel
@@ -46,5 +47,8 @@ object KotprefSettings : KotprefModel(), Settings {
         "auto" -> AppCompatDelegate.MODE_NIGHT_AUTO
         else -> AppCompatDelegate.MODE_NIGHT_AUTO
     }
+
+    override fun registerListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) = preferences.registerOnSharedPreferenceChangeListener(listener)
+    override fun unregisterListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) = preferences.unregisterOnSharedPreferenceChangeListener(listener)
 
 }

--- a/app/src/main/java/org/walleth/data/config/Settings.kt
+++ b/app/src/main/java/org/walleth/data/config/Settings.kt
@@ -1,5 +1,7 @@
 package org.walleth.data.config
 
+import android.content.SharedPreferences
+
 interface Settings {
     var currentFiat: String
     var startupWarningDone: Boolean
@@ -15,4 +17,7 @@ interface Settings {
     fun isLightClientWanted(): Boolean
     fun getNightMode(): Int
     fun getStatsName(): String
+
+    fun registerListener(listener: SharedPreferences.OnSharedPreferenceChangeListener)
+    fun unregisterListener(listener: SharedPreferences.OnSharedPreferenceChangeListener)
 }


### PR DESCRIPTION
Use startActivityForResult for fiat selection, on result update in and out transaction lists.

It is not a general solution as the fiat settings could be change in various places. Currently, `FiatListItemViewHolder`is responsible. (I would suggest to pull this up into the activity)