### PR TITLE
147/Use kethereum:0.36 for functionParams in payment requests

### DIFF
--- a/app/src/main/java/org/walleth/activities/RequestActivity.kt
+++ b/app/src/main/java/org/walleth/activities/RequestActivity.kt
@@ -66,31 +66,32 @@ class RequestActivity : AppCompatActivity() {
 
     private fun refreshQR() {
 
-        if (currentTokenProvider.currentToken.isETH()) {
+        val currentToken = currentTokenProvider.currentToken
+        if (currentToken.isETH()) {
 
             val relevantAddress = currentAddressProvider.getCurrent()
             currentERC67String = ERC681(address = relevantAddress.hex).generateURL()
 
             if (add_value_checkbox.isChecked) {
                 try {
-                    val currentToken = currentTokenProvider.currentToken
-
                     currentERC67String = ERC681(address = relevantAddress.hex,value =value_input_edittext.text.toString().extractValueForToken(currentToken) ).generateURL()
                 } catch (e: NumberFormatException) {
                 }
             }
         } else {
-            val relevantAddress = currentTokenProvider.currentToken.address
-            currentERC67String = ERC681(address = relevantAddress.hex).generateURL()
+            val relevantAddress = currentToken.address.hex
+
+            val userAddress = currentAddressProvider.getCurrent().hex
+            val functionParams = mutableMapOf("address" to userAddress)
             if (add_value_checkbox.isChecked) {
                 try {
-                    currentERC67String = currentERC67String + "?function=transfer(address " +
-                            currentAddressProvider.getCurrent().hex + ", uint " +
-                            value_input_edittext.text.toString() + ")"
+                    functionParams.put("uint256", value_input_edittext.text.toString().extractValueForToken(currentToken).toString())
                 } catch (e: NumberFormatException) {
                 }
             }
 
+            currentERC67String = ERC681(address = relevantAddress, function = "transfer",
+                    functionParams = functionParams).generateURL()
         }
 
         receive_qrcode.setQRCode(currentERC67String)

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         kotlin_version = '1.2.10'
         support_version = '26.1.0'
         firebase_version = '11.6.2'
-        kethereum_version = '0.35'
+        kethereum_version = '0.36'
         arch_version = "1.0.0"
         truth = '0.39'
     }


### PR DESCRIPTION
This PR
* uses functionParms from kethereum:0.36 to build payment requests
* fixes the value for token transfers using atomic units of the token
