### PR TITLE
133/show current and target chain name or id in error

### DIFF
--- a/app/src/androidTest/java/org/walleth/tests/TheCreateTransactionActivity.kt
+++ b/app/src/androidTest/java/org/walleth/tests/TheCreateTransactionActivity.kt
@@ -31,10 +31,12 @@ class TheCreateTransactionActivity {
 
     @Test
     fun rejectsDifferentChainId() {
-        rule.launchActivity(Intent.getIntentOld("ethereum:0x12345@"+(TestApp.mySettings.chain+1)))
+        val chainIdForTransaction = TestApp.mySettings.chain + 1
+        rule.launchActivity(Intent.getIntentOld("ethereum:0x12345@" + chainIdForTransaction))
 
         Espresso.onView(ViewMatchers.withText(R.string.wrong_network)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
-        Espresso.onView(ViewMatchers.withText(R.string.please_switch_network)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        Espresso.onView(ViewMatchers.withText(rule.activity.getString(R.string.please_switch_network, TestApp.networkDefinitionProvider.getCurrent().getNetworkName(), chainIdForTransaction)))
+                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
 
         rule.screenShot("chainId_not_valid")
         Truth.assertThat(rule.activity.isFinishing).isFalse()
@@ -42,11 +44,12 @@ class TheCreateTransactionActivity {
 
     @Test
     fun acceptsDifferentChainId() {
-        TestApp.networkDefinitionProvider
-        rule.launchActivity(Intent.getIntentOld("ethereum:0x12345@"+TestApp.networkDefinitionProvider.getCurrent()))
+        val chainIdForTransaction = TestApp.networkDefinitionProvider.getCurrent().chain.id
+        rule.launchActivity(Intent.getIntentOld("ethereum:0x12345@" + chainIdForTransaction))
 
         Espresso.onView(ViewMatchers.withText(R.string.wrong_network)).check(ViewAssertions.doesNotExist())
-        Espresso.onView(ViewMatchers.withText(R.string.please_switch_network)).check(ViewAssertions.doesNotExist())
+        Espresso.onView(ViewMatchers.withText(rule.activity.getString(R.string.please_switch_network, TestApp.networkDefinitionProvider.getCurrent().getNetworkName(), chainIdForTransaction)))
+                .check(ViewAssertions.doesNotExist())
 
         rule.screenShot("chainId_valid")
         Truth.assertThat(rule.activity.isFinishing).isFalse()

--- a/app/src/main/java/org/walleth/activities/CreateTransactionActivity.kt
+++ b/app/src/main/java/org/walleth/activities/CreateTransactionActivity.kt
@@ -39,6 +39,7 @@ import org.walleth.data.addressbook.resolveNameAsync
 import org.walleth.data.balances.Balance
 import org.walleth.data.networks.CurrentAddressProvider
 import org.walleth.data.networks.NetworkDefinitionProvider
+import org.walleth.data.networks.getNetworkDefinitionByChainID
 import org.walleth.data.tokens.CurrentTokenProvider
 import org.walleth.data.tokens.getEthTokenForChain
 import org.walleth.data.tokens.isETH
@@ -323,7 +324,8 @@ class CreateTransactionActivity : AppCompatActivity() {
 
     private fun showWarningOnWrongNetwork(erc681: ERC681): Boolean {
         if (erc681.chainId != null && erc681.chainId != networkDefinitionProvider.getCurrent().chain.id) {
-            alert(title = R.string.wrong_network, message = R.string.please_switch_network)
+            val chainForTransaction = getNetworkDefinitionByChainID(erc681.chainId!!)?.getNetworkName() ?: erc681.chainId
+            alert(title = getString(R.string.wrong_network), message = getString(R.string.please_switch_network, networkDefinitionProvider.getCurrent().getNetworkName(), chainForTransaction))
             return true
         }
         return false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,7 +182,7 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="network_details">network details</string>
     <string name="network_stats">network stats</string>
     <string name="wrong_network">Wrong Network</string>
-    <string name="please_switch_network">Please switch network</string>
+    <string name="please_switch_network">Please switch network from %1$s to %2$s</string>
     <string name="info_activity_subtitle">Version %s</string>
     <string name="trezor_please_enter_your_pin">Please enter your PIN</string>
     <string name="warning_not_a_valid_address">not a valid address: %s</string>


### PR DESCRIPTION
This PR adds the network name or chain id in case a transaction was meant for a different network.

Towards #133 

![screenshot_1516788852](https://user-images.githubusercontent.com/1449049/35326704-bf3c1dbe-00f7-11e8-9558-afb41c36f373.png)
![screenshot_1516788775](https://user-images.githubusercontent.com/1449049/35326705-bf5c6038-00f7-11e8-93d7-d7144e9d6248.png)
