### PR TITLE
147/parse incoming string for token transfer

### DIFF
--- a/app/src/androidTest/java/org/walleth/infrastructure/TestApp.kt
+++ b/app/src/androidTest/java/org/walleth/infrastructure/TestApp.kt
@@ -37,7 +37,7 @@ class TestApp : App() {
         bind<Settings>() with singleton { mySettings }
         bind<CurrentAddressProvider>() with singleton { currentAddressProvider }
         bind<NetworkDefinitionProvider>() with singleton { networkDefinitionProvider }
-        bind<CurrentTokenProvider>() with singleton { CurrentTokenProvider(instance()) }
+        bind<CurrentTokenProvider>() with singleton { currentTokenProvider }
         bind<AppDatabase>() with singleton { testDatabase }
     }
 
@@ -61,7 +61,7 @@ class TestApp : App() {
         }
         val currentAddressProvider = DefaultCurrentAddressProvider(mySettings)
         val networkDefinitionProvider = NetworkDefinitionProvider(mySettings)
-
+        val currentTokenProvider = CurrentTokenProvider(networkDefinitionProvider)
         lateinit var testDatabase: AppDatabase
         fun resetDB(context: Context) {
             testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()

--- a/app/src/androidTest/java/org/walleth/tests/TheCreateTransactionActivity.kt
+++ b/app/src/androidTest/java/org/walleth/tests/TheCreateTransactionActivity.kt
@@ -6,20 +6,39 @@ import android.support.test.espresso.action.ViewActions
 import android.support.test.espresso.assertion.ViewAssertions
 import android.support.test.espresso.matcher.ViewMatchers
 import com.google.common.truth.Truth
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.kethereum.erc681.generateURL
+import org.kethereum.functions.getTokenTransferTo
+import org.kethereum.functions.getTokenTransferValue
+import org.kethereum.functions.isTokenTransfer
 import org.kethereum.model.Address
 import org.ligi.trulesk.TruleskActivityRule
 import org.walleth.R
 import org.walleth.activities.CreateTransactionActivity
 import org.walleth.data.balances.Balance
+import org.walleth.data.tokens.Token
+import org.walleth.data.tokens.TokenTransfer
+import org.walleth.data.tokens.getEthTokenForChain
+import org.walleth.data.tokens.toERC681
+import org.walleth.functions.decimalsAsMultiplicator
 import org.walleth.infrastructure.TestApp
+import org.walleth.testdata.DEFAULT_TEST_ADDRESS2
 import java.math.BigInteger
+
+val testToken = Token("Test", "TEST", Address("0x01"), 15, TestApp.networkDefinitionProvider.getCurrent().chain, true, false, false, 1)
+val eth = getEthTokenForChain(TestApp.networkDefinitionProvider.getCurrent())
 
 class TheCreateTransactionActivity {
 
     @get:Rule
     var rule = TruleskActivityRule(CreateTransactionActivity::class.java, autoLaunch = false)
+
+    @Before
+    fun setup() {
+        TestApp.testDatabase.transactions.deleteAll()
+    }
 
     @Test
     fun rejectsEmptyAddress() {
@@ -44,9 +63,9 @@ class TheCreateTransactionActivity {
     }
 
     @Test
-    fun acceptsDifferentChainId() {
+    fun acceptsSameChainId() {
         TestApp.networkDefinitionProvider
-        rule.launchActivity(Intent.getIntentOld("ethereum:0x12345@" + TestApp.networkDefinitionProvider.getCurrent()))
+        rule.launchActivity(Intent.getIntentOld("ethereum:0x12345@" + TestApp.mySettings.chain))
 
         Espresso.onView(ViewMatchers.withText(R.string.wrong_network)).check(ViewAssertions.doesNotExist())
         Espresso.onView(ViewMatchers.withText(R.string.please_switch_network)).check(ViewAssertions.doesNotExist())
@@ -62,8 +81,10 @@ class TheCreateTransactionActivity {
     }
 
     @Test
-    fun usesCorrectValuesForETHTransaction() {
-        TestApp.testDatabase.balances.upsert(Balance(TestApp.currentAddressProvider.getCurrent(), Address("0x0"), TestApp.networkDefinitionProvider.getCurrent().chain, 1L, BigInteger.TEN * BigInteger("1" + "0".repeat(18))))
+    fun usesCorrectValuesForETHTransaction1() {
+        TestApp.currentTokenProvider.currentToken = eth
+        TestApp.testDatabase.balances.upsert(Balance(TestApp.currentAddressProvider.getCurrent(), eth.address, TestApp.networkDefinitionProvider.getCurrent().chain, 1L, BigInteger.TEN * BigInteger("1" + "0".repeat(18))))
+
         rule.launchActivity(Intent.getIntentOld("ethereum:0x123456?value=1"))
 
         Espresso.onView(ViewMatchers.withId(R.id.fab)).perform(ViewActions.closeSoftKeyboard(), ViewActions.click())
@@ -71,5 +92,86 @@ class TheCreateTransactionActivity {
         val allTransactionsForAddress = TestApp.testDatabase.transactions.getAllTransactionsForAddress(listOf(Address("0x123456")))
         Truth.assertThat(allTransactionsForAddress).hasSize(1)
         Truth.assertThat(allTransactionsForAddress.get(0).transaction.to?.hex).isEqualTo("0x123456")
+        Truth.assertThat(allTransactionsForAddress.get(0).transaction.value).isEqualTo(BigInteger("1"))
+
+    }
+
+    @Test
+    fun usesCorrectValuesForETHTransaction2() {
+        TestApp.currentTokenProvider.currentToken = testToken
+        TestApp.testDatabase.balances.upsert(Balance(TestApp.currentAddressProvider.getCurrent(), eth.address, TestApp.networkDefinitionProvider.getCurrent().chain, 1L, BigInteger.TEN * BigInteger("1" + "0".repeat(18))))
+        rule.launchActivity(Intent.getIntentOld("ethereum:0x123456?value=1"))
+
+        Espresso.onView(ViewMatchers.withId(R.id.fab)).perform(ViewActions.closeSoftKeyboard(), ViewActions.click())
+
+        val allTransactionsForAddress = TestApp.testDatabase.transactions.getAllTransactionsForAddress(listOf(Address("0x123456")))
+        Truth.assertThat(allTransactionsForAddress).hasSize(1)
+        Truth.assertThat(allTransactionsForAddress.get(0).transaction.to?.hex).isEqualTo("0x123456")
+        Truth.assertThat(allTransactionsForAddress.get(0).transaction.value).isEqualTo(BigInteger("1"))
+
+    }
+
+    @Test
+    fun usesCorrectValuesForCurrentTokenTransfer() {
+        TestApp.testDatabase.tokens.addIfNotPresent(listOf(testToken))
+        TestApp.currentTokenProvider.currentToken = testToken
+
+        val toAddress = DEFAULT_TEST_ADDRESS2
+        val uri = TokenTransfer(toAddress, testToken, BigInteger.TEN).toERC681().generateURL()
+
+        TestApp.testDatabase.balances.upsert(Balance(TestApp.currentAddressProvider.getCurrent(), eth.address, TestApp.networkDefinitionProvider.getCurrent().chain, 1L, BigInteger.TEN * BigInteger("1" + "0".repeat(18))))
+        TestApp.testDatabase.balances.upsert(Balance(TestApp.currentAddressProvider.getCurrent(), testToken.address, TestApp.networkDefinitionProvider.getCurrent().chain, 1L, BigInteger.TEN * BigInteger("1" + "0".repeat(18))))
+
+        rule.launchActivity(Intent.getIntentOld(uri))
+        Espresso.onView(ViewMatchers.withId(R.id.fab)).perform(ViewActions.closeSoftKeyboard(), ViewActions.click())
+
+        val allTransactionsForAddress = TestApp.testDatabase.transactions.getAllTransactionsForAddress(listOf(toAddress))
+        Truth.assertThat(allTransactionsForAddress).hasSize(0)
+
+        val allTransactionsForToken = TestApp.testDatabase.transactions.getAllTransactionsForAddress(listOf(testToken.address))
+        Truth.assertThat(allTransactionsForToken).hasSize(1)
+        Truth.assertThat(allTransactionsForToken.get(0).transaction.isTokenTransfer()).isTrue()
+        Truth.assertThat(allTransactionsForToken.get(0).transaction.getTokenTransferTo()).isEqualTo(toAddress)
+        Truth.assertThat(allTransactionsForToken.get(0).transaction.getTokenTransferValue()).isEqualTo(BigInteger.TEN)
+    }
+
+    @Test
+    fun usesCorrectValuesForNewTokenTransfer() {
+        val eth = getEthTokenForChain(TestApp.networkDefinitionProvider.getCurrent())
+        TestApp.currentTokenProvider.currentToken = eth
+        TestApp.testDatabase.tokens.addIfNotPresent(listOf(testToken))
+        TestApp.testDatabase.balances.upsert(Balance(TestApp.currentAddressProvider.getCurrent(), eth.address, TestApp.networkDefinitionProvider.getCurrent().chain, 1L, BigInteger.TEN * eth.decimalsAsMultiplicator().toBigInteger()))
+        TestApp.testDatabase.balances.upsert(Balance(TestApp.currentAddressProvider.getCurrent(), testToken.address, TestApp.networkDefinitionProvider.getCurrent().chain, 1L, BigInteger.TEN * testToken.decimalsAsMultiplicator().toBigInteger()))
+
+        val toAddress = DEFAULT_TEST_ADDRESS2
+        val uri = TokenTransfer(toAddress, testToken, BigInteger.TEN).toERC681().generateURL()
+
+
+        rule.launchActivity(Intent.getIntentOld(uri))
+        Espresso.onView(ViewMatchers.withId(R.id.fab)).perform(ViewActions.closeSoftKeyboard(), ViewActions.click())
+
+        val allTransactionsForAddress = TestApp.testDatabase.transactions.getAllTransactionsForAddress(listOf(toAddress))
+        Truth.assertThat(allTransactionsForAddress).hasSize(0)
+
+        val allTransactionsForToken = TestApp.testDatabase.transactions.getAllTransactionsForAddress(listOf(testToken.address))
+        Truth.assertThat(allTransactionsForToken).hasSize(1)
+        Truth.assertThat(allTransactionsForToken.get(0).transaction.isTokenTransfer()).isTrue()
+        Truth.assertThat(allTransactionsForToken.get(0).transaction.getTokenTransferTo()).isEqualTo(toAddress)
+        Truth.assertThat(allTransactionsForToken.get(0).transaction.getTokenTransferValue()).isEqualTo(BigInteger.TEN)
+    }
+
+    @Test
+    fun doesNotAcceptUnknownTokenTransfer() {
+        TestApp.currentTokenProvider.currentToken = getEthTokenForChain(TestApp.networkDefinitionProvider.getCurrent())
+
+        val toAddress = DEFAULT_TEST_ADDRESS2
+        val uri = TokenTransfer(toAddress, testToken, BigInteger.TEN).toERC681().generateURL()
+
+        rule.launchActivity(Intent.getIntentOld(uri))
+
+        Espresso.onView(ViewMatchers.withText(R.string.unknown_token)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+
+        rule.screenShot("unknown_token")
+        Truth.assertThat(rule.activity.isFinishing).isFalse()
     }
 }

--- a/app/src/main/java/org/walleth/activities/CreateTransactionActivity.kt
+++ b/app/src/main/java/org/walleth/activities/CreateTransactionActivity.kt
@@ -1,6 +1,7 @@
 package org.walleth.activities
 
 import android.app.Activity
+import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.Transformations
 import android.content.Intent
@@ -39,16 +40,16 @@ import org.walleth.data.addressbook.resolveNameAsync
 import org.walleth.data.balances.Balance
 import org.walleth.data.networks.CurrentAddressProvider
 import org.walleth.data.networks.NetworkDefinitionProvider
-import org.walleth.data.tokens.CurrentTokenProvider
-import org.walleth.data.tokens.getEthTokenForChain
-import org.walleth.data.tokens.isETH
+import org.walleth.data.tokens.*
 import org.walleth.data.transactions.TransactionState
 import org.walleth.data.transactions.toEntity
 import org.walleth.functions.asBigDecimal
 import org.walleth.functions.decimalFormat
+import org.walleth.functions.decimalsAsMultiplicator
 import org.walleth.functions.decimalsInZeroes
 import org.walleth.kethereum.android.TransactionParcel
 import org.walleth.khex.toHexString
+import org.walleth.ui.asyncAwait
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.BigInteger.ONE
@@ -70,6 +71,7 @@ class CreateTransactionActivity : AppCompatActivity() {
     private val appDatabase: AppDatabase by LazyKodein(appKodein).instance()
     private var currentBalance: Balance? = null
     private var lastWarningURI: String? = null
+    private var currentBalanceLive: LiveData<Balance>? = null
 
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -116,11 +118,8 @@ class CreateTransactionActivity : AppCompatActivity() {
         supportActionBar?.subtitle = getString(R.string.create_transaction_subtitle)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        Transformations.switchMap(currentAddressProvider, { address ->
-            appDatabase.balances.getBalanceLive(address, currentTokenProvider.currentToken.address, networkDefinitionProvider.getCurrent().chain)
-        }).observe(this, Observer {
-            currentBalance = it
-        })
+        onCurrentTokenChanged()
+
         currentAddressProvider.observe(this, Observer { address ->
             address?.let {
                 appDatabase.addressBook.getByAddressAsync(address) {
@@ -135,12 +134,6 @@ class CreateTransactionActivity : AppCompatActivity() {
         })
 
         gas_price_input.setText(DEFAULT_GAS_PRICE.toString())
-
-        if (currentTokenProvider.currentToken.isETH()) {
-            gas_limit_input.setText(DEFAULT_GAS_LIMIT_ETH_TX.toString())
-        } else {
-            gas_limit_input.setText(DEFAULT_GAS_LIMIT_ERC_20_TX.toString())
-        }
 
         sweep_button.setOnClickListener {
             val balance = currentBalanceSafely()
@@ -205,9 +198,24 @@ class CreateTransactionActivity : AppCompatActivity() {
             amount_value.setValue(currentAmount ?: ZERO, currentTokenProvider.currentToken)
         }
 
-        amount_value.setValue(currentAmount ?: ZERO, currentTokenProvider.currentToken)
+    }
 
+    private fun onCurrentTokenChanged() {
+        val currentToken = currentTokenProvider.currentToken
+        currentBalanceLive = Transformations.switchMap(currentAddressProvider, { address ->
+            appDatabase.balances.getBalanceLive(address, currentToken.address, networkDefinitionProvider.getCurrent().chain)
+        })
+        currentBalanceLive!!.observe(this, Observer {
+            currentBalance = it
+        })
 
+        amount_value.setValue(currentAmount ?: ZERO, currentToken)
+
+        if (currentToken.isETH()) {
+            gas_limit_input.setText(DEFAULT_GAS_LIMIT_ETH_TX.toString())
+        } else {
+            gas_limit_input.setText(DEFAULT_GAS_LIMIT_ERC_20_TX.toString())
+        }
     }
 
     private fun onFabClick(isTrezorTransaction: Boolean) {
@@ -216,6 +224,8 @@ class CreateTransactionActivity : AppCompatActivity() {
         } else if (currentAmount == null) {
             alert(R.string.create_tx_error_amount_must_be_specified)
         } else if (currentTokenProvider.currentToken.isETH() && currentAmount!! + gas_price_input.asBigInit() * gas_limit_input.asBigInit() > currentBalanceSafely()) {
+            alert(R.string.create_tx_error_not_enough_funds)
+        } else if (!currentTokenProvider.currentToken.isETH() && currentAmount!! > currentBalanceSafely()) {
             alert(R.string.create_tx_error_not_enough_funds)
         } else if (nonce_input.text.isBlank()) {
             alert(title = R.string.nonce_invalid, message = R.string.please_enter_name)
@@ -298,21 +308,45 @@ class CreateTransactionActivity : AppCompatActivity() {
 
                 showWarningOnWrongNetwork(erc681)
 
-                currentToAddress =
-                        if (erc681.address != null) {
-                            to_address.text = erc681.address
-                            Address(erc681.address!!).apply {
-                                appDatabase.addressBook.resolveNameAsync(this) {
-                                    to_address.text = it
-                                }
-                            }
-                        } else {
-                            null
-                        }
+                currentToAddress = erc681.getToAddress()?.apply {
+                    to_address.text = this.hex
+                    appDatabase.addressBook.resolveNameAsync(this) {
+                        to_address.text = it
+                    }
+                }
 
-                erc681.value?.let {
-                    amount_input.setText((BigDecimal(it).setScale(4) / BigDecimal("1" + currentTokenProvider.currentToken.decimalsInZeroes())).toString())
-                    currentAmount = it
+                if (erc681.isTokenTransfer()) {
+                    if (erc681.address != null) {
+                        { appDatabase.tokens.forAddress(Address(erc681.address!!)) }.asyncAwait { token ->
+                            if (token != null) {
+
+                                if (token != currentTokenProvider.currentToken) {
+                                    currentTokenProvider.currentToken = token
+                                    currentBalanceLive!!.removeObservers(this)
+                                    onCurrentTokenChanged()
+                                }
+
+                                amount_input.setText(BigDecimal(erc681.getValueForTokenTransfer()).divide(token.decimalsAsMultiplicator()).toPlainString())
+                            } else {
+                                alert(getString(R.string.add_token_manually, erc681.address), getString(R.string.unknown_token))
+                            }
+                        }
+                    } else {
+                        alert(getString(R.string.no_token_address), getString(R.string.unknown_token))
+                    }
+                } else {
+                    if (!currentTokenProvider.currentToken.isETH()) {
+                        currentTokenProvider.currentToken = getEthTokenForChain(networkDefinitionProvider.getCurrent())
+                        currentBalanceLive!!.removeObservers(this)
+                        onCurrentTokenChanged()
+                    }
+                    erc681.value?.let {
+                        amount_input.setText(BigDecimal(it).divide(currentTokenProvider.currentToken.decimalsAsMultiplicator()).toPlainString())
+
+                        // when called from onCreate() the afterEdit hook is not yet added
+                        setAmountFromETHString(amount_input.text.toString())
+                        amount_value.setValue(currentAmount ?: ZERO, currentTokenProvider.currentToken)
+                    }
                 }
             } else {
                 currentToAddress = null

--- a/app/src/main/java/org/walleth/data/tokens/TokenTransfer.kt
+++ b/app/src/main/java/org/walleth/data/tokens/TokenTransfer.kt
@@ -1,0 +1,40 @@
+package org.walleth.data.tokens
+
+import org.kethereum.erc681.ERC681
+import org.kethereum.model.Address
+import java.math.BigInteger
+
+data class TokenTransfer(
+        val to: Address,
+        val token: Token,
+        val value: BigInteger)
+
+fun TokenTransfer.toERC681() = ERC681(address = token.address.hex, function = "transfer",
+        functionParams = mapOf("address" to to.hex, "uint256" to value.toString()))
+
+fun ERC681.getToAddress(): Address? {
+    val address = if (this.function == "transfer") {
+        this.functionParams["address"]
+    } else {
+        this.address
+    }
+    if (address != null) {
+        return Address(address)
+    } else {
+        return null
+    }
+}
+
+fun ERC681.isTokenTransfer() = this.function == "transfer"
+fun ERC681.getValueForTokenTransfer(): BigInteger {
+    val value = this.functionParams["uint256"]
+    if (value != null) {
+        try {
+            return BigInteger(value)
+        } catch (ignore: NumberFormatException) {
+            return BigInteger.ZERO
+        }
+    } else {
+        return BigInteger.ZERO
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,4 +188,7 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="warning_not_a_valid_address">not a valid address: %s</string>
     <string name="title_invalid_address_alert">invalid_address</string>
     <string name="create_transation_from_label">From:</string>
+    <string name="unknown_token">Unknown Token</string>
+    <string name="add_token_manually">Please add token with address %1$s manually.</string>
+    <string name="no_token_address">Token address is missing!</string>
 </resources>


### PR DESCRIPTION
This PR adds the feature to handle token transfer URIs.

Methods that depend on the currentToken have been moved into one method such that in the future the user can change the token as well (#105).

All relevant parameter names and values for ERC681 have been used only in TokenTransfer.

`TokenTransfer` could later be used as part of the transaction entity to store and retrieve token transfer transactions

Scanning an address (for receiver) can now also be an ERC681 string