### PR TITLE
97/add alert dialog to store default gas price

### DIFF
--- a/app/src/main/java/org/walleth/data/config/KotprefSettings.kt
+++ b/app/src/main/java/org/walleth/data/config/KotprefSettings.kt
@@ -5,7 +5,10 @@ import android.preference.PreferenceManager
 import android.support.v7.app.AppCompatDelegate
 import com.chibatching.kotpref.KotprefModel
 import org.walleth.R
+import org.walleth.data.DEFAULT_GAS_PRICE
+import org.walleth.data.networks.NetworkDefinition
 import org.walleth.data.networks.RINKEBY_CHAIN_ID
+import org.walleth.functions.asBigDecimal
 import java.math.BigInteger
 import java.security.SecureRandom
 
@@ -55,4 +58,14 @@ object KotprefSettings : KotprefModel(), Settings {
     override fun registerListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) = preferences.registerOnSharedPreferenceChangeListener(listener)
     override fun unregisterListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) = preferences.unregisterOnSharedPreferenceChangeListener(listener)
 
+    override fun getGasPriceFor(current: NetworkDefinition): BigInteger {
+        val gasPrice = sharedPreferences.getString("KEY_GAS_PRICE" + current.chain.id, null)
+        return gasPrice?.asBigDecimal()?.toBigInteger() ?: DEFAULT_GAS_PRICE
+    }
+
+    override fun storeGasPriceFor(gasPrice: BigInteger, network: NetworkDefinition) {
+        sharedPreferences.edit()
+                .putString("KEY_GAS_PRICE" + network.chain.id, gasPrice.toString())
+                .apply()
+    }
 }

--- a/app/src/main/java/org/walleth/data/config/Settings.kt
+++ b/app/src/main/java/org/walleth/data/config/Settings.kt
@@ -1,6 +1,8 @@
 package org.walleth.data.config
 
 import android.content.SharedPreferences
+import org.walleth.data.networks.NetworkDefinition
+import java.math.BigInteger
 
 interface Settings {
     var currentFiat: String
@@ -26,4 +28,7 @@ interface Settings {
 
     fun registerListener(listener: SharedPreferences.OnSharedPreferenceChangeListener)
     fun unregisterListener(listener: SharedPreferences.OnSharedPreferenceChangeListener)
+
+    fun getGasPriceFor(current: NetworkDefinition): BigInteger
+    fun storeGasPriceFor(gasPrice:BigInteger, network: NetworkDefinition)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,4 +188,7 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="warning_not_a_valid_address">not a valid address: %s</string>
     <string name="title_invalid_address_alert">invalid_address</string>
     <string name="create_transation_from_label">From:</string>
+    <string name="store_gas_price">Store the current gas price as default?</string>
+    <string name="save">Save</string>
+    <string name="no">No</string>
 </resources>


### PR DESCRIPTION
This PR adds a dialog to store the default gas price.

After a transaction has been submitted that gas price is checked against the current default value and if it is different the user is asked whether the new gas price should be stored as default.

The value depends on the network.
![screenshot_1516888736](https://user-images.githubusercontent.com/1449049/35392015-ba80c3e4-01e0-11e8-96f1-c7233098e468.png)
