### PR TITLE
74/Show chooser handling ERC67 strings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,7 +46,8 @@
         <activity android:name="org.walleth.activities.SwitchAccountActivity"/>
         <activity android:name="org.walleth.activities.PreferenceActivity"/>
         <activity android:name="org.walleth.activities.ViewTransactionActivity"/>
-        <activity android:name="org.walleth.activities.CreateTransactionActivity">
+        <activity android:name="org.walleth.activities.CreateTransactionActivity"/>
+        <activity android:name="org.walleth.activities.IntentHandlerActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
 

--- a/app/src/main/java/org/walleth/activities/IntentHandlerActivity.kt
+++ b/app/src/main/java/org/walleth/activities/IntentHandlerActivity.kt
@@ -1,0 +1,50 @@
+package org.walleth.activities
+
+import android.content.DialogInterface.OnClickListener
+import android.content.Intent
+import android.os.Bundle
+import android.support.v7.app.AlertDialog
+import android.support.v7.app.AppCompatActivity
+import org.kethereum.erc681.toERC681
+import org.ligi.kaxtui.alert
+import org.walleth.R
+import org.walleth.data.tokens.isTokenTransfer
+import java.math.BigInteger.ZERO
+
+class IntentHandlerActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val erc681 = intent.data.toString().toERC681()
+        if (erc681.address == null || erc681.isTokenTransfer() || erc681.value != null && erc681.value != ZERO) {
+            startActivity(Intent(this, CreateTransactionActivity::class.java).apply {
+                setData(intent.data)
+            })
+            finish()
+        } else {
+            AlertDialog.Builder(this)
+                    .setTitle(R.string.select_action_messagebox_title)
+                    .setItems(R.array.scan_hex_choices, { _, which ->
+                        when (which) {
+                            0 -> {
+                                startCreateAccountActivity(erc681.address!!)
+                                finish()
+                            }
+                            1 -> {
+                                startActivity(Intent(this, CreateTransactionActivity::class.java).apply {
+                                    setData(intent.data)
+                                })
+                                finish()
+                            }
+                            2 -> {
+                                alert("TODO", "add token definition", OnClickListener { _, _ -> finish() })
+                            }
+                        }
+                    })
+                    .setNegativeButton(android.R.string.cancel) { _, _ ->
+                        finish()
+                    }
+                    .show()
+        }
+    }
+}


### PR DESCRIPTION
This PR add an activity that handles "ethereum:" intents (removes the intent filter from CreateTransactionActivity)

It delegates to CreateTransactionActivity if 
- no address is given (because there error handling is implemented)
- it is a token transfer
- if it has a value > 0 attached

otherwise it shows the same action chooser for addresses as when scanning an address.

Fixes #74 

![device-2018-02-02-114749](https://user-images.githubusercontent.com/1449049/35729539-53304fcc-080f-11e8-984f-72c88812ca2f.png)
