### PR TITLE
104/Add snackbar to paste an ethereum string

### DIFF
--- a/app/src/main/java/org/walleth/activities/MainActivity.kt
+++ b/app/src/main/java/org/walleth/activities/MainActivity.kt
@@ -2,11 +2,12 @@ package org.walleth.activities
 
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.Observer
-import android.content.Intent
-import android.content.SharedPreferences
+import android.content.*
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
+import android.support.design.widget.BaseTransientBottomBar
+import android.support.design.widget.Snackbar
 import android.support.v7.app.ActionBarDrawerToggle
 import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
@@ -22,6 +23,7 @@ import kotlinx.android.synthetic.main.activity_main_in_drawer_container.*
 import kotlinx.android.synthetic.main.value.*
 import org.json.JSONObject
 import org.kethereum.erc681.isEthereumURLString
+import org.kethereum.erc681.toERC681
 import org.ligi.kaxt.recreateWhenPossible
 import org.ligi.kaxt.setVisibility
 import org.ligi.kaxt.startActivityFromClass
@@ -41,6 +43,7 @@ import org.walleth.ui.TransactionAdapterDirection.OUTGOING
 import org.walleth.ui.TransactionRecyclerAdapter
 import java.math.BigInteger.ZERO
 
+private const val KEY_LAST_PASTED_DATA: String = "LAST_PASTED_DATA"
 
 class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceChangeListener {
 
@@ -58,6 +61,8 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     private var balanceLiveData: LiveData<Balance>? = null
     private val onboardingController by lazy { OnboardingController(this, settings) }
 
+    private var lastPastedData: String? = null
+
     override fun onResume() {
         super.onResume()
 
@@ -67,6 +72,31 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         }
         lastNightMode = settings.getNightMode()
         setCurrentBalanceObserver()
+
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        if (clipboard.hasPrimaryClip()) {
+            val item = clipboard.primaryClip.getItemAt(0).text?.toString()
+            val erc681 = item?.toERC681()
+            if (erc681?.address != null && item != lastPastedData) {
+                Snackbar.make(fab, R.string.paste_from_clipboard, Snackbar.LENGTH_INDEFINITE)
+                        .addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+                            override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                                if (event == DISMISS_EVENT_ACTION || event == DISMISS_EVENT_SWIPE) {
+                                    lastPastedData = item
+                                }
+                            }
+                        })
+                        .setAction(R.string.paste_from_clipboard_action, {
+                            alert(R.string.copied_string_warning_message, R.string.copied_string_warning_title, DialogInterface.OnClickListener { _, _ ->
+                                startActivity(Intent(this@MainActivity, CreateTransactionActivity::class.java).apply {
+                                    data = Uri.parse(item)
+                                })
+                            })
+
+                        })
+                        .show()
+            }
+        }
     }
 
     private fun String.isJSONKey() = try {
@@ -241,6 +271,9 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
             startScanActivityForResult(this)
         }
 
+        if (savedInstanceState != null) {
+            lastPastedData = savedInstanceState.getString(KEY_LAST_PASTED_DATA)
+        }
     }
 
 
@@ -294,6 +327,11 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
             transaction_recycler_in.adapter?.notifyDataSetChanged()
             transaction_recycler_in.adapter?.notifyDataSetChanged()
         }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle?) {
+        super.onSaveInstanceState(outState)
+        outState!!.putString(KEY_LAST_PASTED_DATA, lastPastedData)
     }
 
     override fun onDestroy() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,4 +200,8 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="save">Save</string>
     <string name="no">No</string>
     <string name="default_gas_price">Default gas price for %1$s</string>
+    <string name="paste_from_clipboard">Copied Ethereum details detected</string>
+    <string name="paste_from_clipboard_action">Use it</string>
+    <string name="copied_string_warning_title">Warning</string>
+    <string name="copied_string_warning_message">Copied details could have been hampered with by other apps. Please verify the details!</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,5 +203,5 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="paste_from_clipboard">Copied Ethereum details detected</string>
     <string name="paste_from_clipboard_action">Use it</string>
     <string name="copied_string_warning_title">Warning</string>
-    <string name="copied_string_warning_message">Copied details could have been hampered with by other apps. Please verify the details!</string>
+    <string name="copied_string_warning_message">Copied details could have been tampered with by other apps. Please verify the details!</string>
 </resources>


### PR DESCRIPTION
This PR adds a snackbar in the main activity when an ethereum string is in the clipboard (and if it was not yet used)

Before using the string the user is warned about possible attacks. See #14 

This fixes #104 

![device-2018-02-02-130047](https://user-images.githubusercontent.com/1449049/35732384-783e69ac-0819-11e8-910b-06ef2a082226.png)

![device-2018-02-02-130108](https://user-images.githubusercontent.com/1449049/35732383-7813f44c-0819-11e8-8441-a51006b50867.png)
