### PR TITLE
64/add fullscreen qr code activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
 
         <activity android:name="org.walleth.activities.SwitchNetworkActivity"/>
         <activity android:name="org.walleth.activities.RequestActivity"/>
+        <activity android:name=".activities.FullscreenQRCodeActivity"/>
         <activity android:name="org.walleth.activities.InfoActivity"/>
         <activity android:name="org.walleth.activities.DebugWallethActivity"/>
         <activity android:name="org.walleth.activities.OfflineTransactionActivity"

--- a/app/src/main/java/org/walleth/activities/FullscreenQRCodeActivity.kt
+++ b/app/src/main/java/org/walleth/activities/FullscreenQRCodeActivity.kt
@@ -8,10 +8,9 @@ import kotlinx.android.synthetic.main.activity_fullscreen_qrcode.*
 import org.walleth.R
 import org.walleth.functions.setQRCode
 
-const val KEY_ERC681 = "extra_erc681"
+const val KEY_ERC681 = "erc681"
 
 class FullscreenQRCodeActivity : AppCompatActivity() {
-    private var fullBrightnessSet = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -43,7 +42,6 @@ class FullscreenQRCodeActivity : AppCompatActivity() {
         val params = win.attributes
         params.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_FULL
         win.attributes = params
-        fullBrightnessSet = true
     }
 
 }

--- a/app/src/main/java/org/walleth/activities/FullscreenQRCodeActivity.kt
+++ b/app/src/main/java/org/walleth/activities/FullscreenQRCodeActivity.kt
@@ -1,0 +1,49 @@
+package org.walleth.activities
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.view.MenuItem
+import android.view.WindowManager
+import kotlinx.android.synthetic.main.activity_fullscreen_qrcode.*
+import org.walleth.R
+import org.walleth.functions.setQRCode
+
+const val KEY_ERC681 = "extra_erc681"
+
+class FullscreenQRCodeActivity : AppCompatActivity() {
+    private var fullBrightnessSet = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_fullscreen_qrcode)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.subtitle = getString(R.string.request_transaction_subtitle)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val currentERC681 = intent.getStringExtra(KEY_ERC681)
+        fullscreen_barcode.setQRCode(currentERC681)
+        alternativeBarcodeText.text = currentERC681
+        setToFullBrightness()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
+        if (item?.itemId == android.R.id.home) {
+            finish()
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun setToFullBrightness() {
+        val win = window
+        val params = win.attributes
+        params.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_FULL
+        win.attributes = params
+        fullBrightnessSet = true
+    }
+
+}

--- a/app/src/main/java/org/walleth/activities/RequestActivity.kt
+++ b/app/src/main/java/org/walleth/activities/RequestActivity.kt
@@ -46,7 +46,7 @@ class RequestActivity : AppCompatActivity() {
         refreshQR()
 
 
-        val initText = getString(if (networkDefinitionProvider.getCurrent().isNoTestNet() ) {
+        val initText = getString(if (networkDefinitionProvider.getCurrent().isNoTestNet()) {
             R.string.request_hint_no_test_net
         } else {
             R.string.request_hint_test_net
@@ -62,6 +62,12 @@ class RequestActivity : AppCompatActivity() {
         value_input_edittext.doAfterEdit {
             refreshQR()
         }
+
+        receive_qrcode.setOnClickListener({
+            startActivity(Intent(this, FullscreenQRCodeActivity::class.java).apply {
+                putExtra(KEY_ERC681, currentERC67String)
+            })
+        })
     }
 
     private fun refreshQR() {
@@ -74,7 +80,7 @@ class RequestActivity : AppCompatActivity() {
 
             if (add_value_checkbox.isChecked) {
                 try {
-                    currentERC67String = ERC681(address = relevantAddress.hex,value =value_input_edittext.text.toString().extractValueForToken(currentToken) ).generateURL()
+                    currentERC67String = ERC681(address = relevantAddress.hex, value = value_input_edittext.text.toString().extractValueForToken(currentToken)).generateURL()
                 } catch (e: NumberFormatException) {
                 }
             }

--- a/app/src/main/res/layout/activity_fullscreen_qrcode.xml
+++ b/app/src/main/res/layout/activity_fullscreen_qrcode.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+
+    android:background="@android:color/white">
+
+    <ImageView
+        android:id="@+id/fullscreen_barcode"
+        android:layout_width="match_parent"
+        android:layout_height="0dip"
+        android:layout_weight="1"/>
+
+    <TextView
+        android:id="@+id/alternativeBarcodeText"
+        android:padding="16dp"
+        android:textColor="@android:color/black"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"/>
+
+</LinearLayout>


### PR DESCRIPTION
This PR adds the possibility to click on the qr code in the request screen and see the qr code in full screen.

Towards #64 

![device-2018-02-08-231840](https://user-images.githubusercontent.com/1449049/36001402-71001ebc-0d26-11e8-86d7-5d7a6aae7cb6.png)
