### PR TITLE
108/move hints from edit texts to input layouts, extract strings

### DIFF
--- a/app/src/main/res/layout/activity_account_create.xml
+++ b/app/src/main/res/layout/activity_account_create.xml
@@ -16,11 +16,11 @@
             <android.support.design.widget.TextInputLayout
                     android:padding="16dp"
                     android:id="@+id/name_input_container"
+                    android:hint="@string/input_hint_account_name"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
                 <android.support.design.widget.TextInputEditText
                         android:id="@+id/nameInput"
-                        android:hint="@string/input_hint_account_name"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"/>
             </android.support.design.widget.TextInputLayout>
@@ -29,11 +29,11 @@
             <android.support.design.widget.TextInputLayout
                     android:padding="16dp"
                     android:id="@+id/note_input_container"
+                    android:hint="@string/input_hint_notes"
                     android:layout_below="@+id/name_input_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
                 <android.support.design.widget.TextInputEditText
-                        android:hint="@string/input_hint_notes"
                         android:id="@+id/noteInput"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"/>
@@ -47,12 +47,12 @@
             android:layout_height="wrap_content">
         <android.support.design.widget.TextInputLayout
                 android:id="@+id/hex_input_container"
+                android:hint="@string/input_hint_address"
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:layout_height="wrap_content">
             <android.support.design.widget.TextInputEditText
                     android:id="@+id/hexInput"
-                    android:hint="@string/input_hint_address"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
         </android.support.design.widget.TextInputLayout>

--- a/app/src/main/res/layout/activity_account_edit.xml
+++ b/app/src/main/res/layout/activity_account_edit.xml
@@ -10,21 +10,21 @@
         tools:context="org.walleth.activities.MainActivity">
 
     <android.support.design.widget.TextInputLayout
+            android:hint="@string/input_hint_account_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
         <android.support.design.widget.TextInputEditText
                 android:id="@+id/nameInput"
-                android:hint="account name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
     </android.support.design.widget.TextInputLayout>
 
 
     <android.support.design.widget.TextInputLayout
+            android:hint="@string/input_hint_notes"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
         <android.support.design.widget.TextInputEditText
-                android:hint="notes"
                 android:id="@+id/noteInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/activity_create_token.xml
+++ b/app/src/main/res/layout/activity_create_token.xml
@@ -12,11 +12,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
         <android.support.design.widget.TextInputLayout
+                android:hint="@string/input_hint_token_name"
                 android:minWidth="127dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
             <android.support.design.widget.TextInputEditText
-                    android:hint="Token Name"
                     android:minWidth="128dp"
                     android:maxLength="5"
                     android:id="@+id/token_name_input"
@@ -26,10 +26,10 @@
 
 
         <android.support.design.widget.TextInputLayout
+                android:hint="@string/input_hint_token_address"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
             <android.support.design.widget.TextInputEditText
-                    android:hint="Token Address"
                     android:minWidth="128dp"
                     android:id="@+id/token_address_input"
                     android:layout_width="match_parent"
@@ -37,10 +37,10 @@
         </android.support.design.widget.TextInputLayout>
 
         <android.support.design.widget.TextInputLayout
+                android:hint="@string/input_hint_decimals"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
             <android.support.design.widget.TextInputEditText
-                    android:hint="Decimals"
                     android:minWidth="128dp"
                     android:id="@+id/token_decimals_input"
                     android:inputType="number"

--- a/app/src/main/res/layout/activity_create_transaction.xml
+++ b/app/src/main/res/layout/activity_create_transaction.xml
@@ -107,11 +107,11 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content">
                 <android.support.design.widget.TextInputLayout
+                        android:hint="@string/create_tx_please_specify_amount"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content">
                     <android.support.design.widget.TextInputEditText
                             android:id="@+id/amount_input"
-                            android:hint="@string/create_tx_please_specify_amount"
                             android:digits="0123456789."
                             android:minWidth="256dp"
                             android:inputType="numberDecimal"
@@ -155,10 +155,10 @@
                           android:layout_below="@id/fee_value_view"
                           android:id="@+id/gas_price_input_container">
                 <android.support.design.widget.TextInputLayout
+                        android:hint="@string/create_tx_gas_price"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content">
                     <android.support.design.widget.TextInputEditText
-                            android:hint="@string/create_tx_gas_price"
                             android:minWidth="128dp"
                             android:id="@+id/gas_price_input"
                             android:inputType="number|numberDecimal"
@@ -176,11 +176,11 @@
                     android:paddingLeft="16dp"
                     android:layout_below="@id/gas_price_input_container"
                     android:id="@+id/gas_limit_input_container"
+                    android:hint="@string/create_tx_gas_limit"
                     android:visibility="gone"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content">
                 <android.support.design.widget.TextInputEditText
-                        android:hint="@string/create_tx_gas_limit"
                         android:minWidth="128dp"
                         android:id="@+id/gas_limit_input"
                         android:inputType="number|numberDecimal"
@@ -201,11 +201,11 @@
                     android:paddingLeft="16dp"
                     android:layout_below="@id/nonce_title"
                     android:id="@+id/nonce_input_container"
+                    android:hint="@string/create_tx_nonce"
                     android:visibility="gone"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content">
                 <android.support.design.widget.TextInputEditText
-                        android:hint="@string/create_tx_nonce"
                         android:minWidth="128dp"
                         android:id="@+id/nonce_input"
                         android:inputType="number|numberDecimal"

--- a/app/src/main/res/layout/activity_import_json.xml
+++ b/app/src/main/res/layout/activity_import_json.xml
@@ -18,6 +18,7 @@
 
             <android.support.design.widget.TextInputLayout
                     android:id="@+id/account_name_container"
+                    android:hint="@string/key_import_account_name_input_hint"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
                 <android.support.design.widget.TextInputEditText
@@ -26,7 +27,6 @@
                         android:layout_height="wrap_content"
                         android:layout_centerHorizontal="true"
                         android:fontFamily="sans-serif"
-                        android:hint="@string/key_import_account_name_input_hint"
                         android:textSize="16sp"
                         android:padding="16dp"/>
             </android.support.design.widget.TextInputLayout>
@@ -53,6 +53,7 @@
             <android.support.design.widget.TextInputLayout
                     android:id="@+id/password_container"
                     style="@style/password_textinputlayout"
+                    android:hint="@string/key_import_password_input_hint"
                     android:layout_below="@id/key_type_select"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
@@ -63,15 +64,14 @@
                         android:layout_height="wrap_content"
                         android:layout_centerHorizontal="true"
                         android:fontFamily="sans-serif"
-                        android:hint="@string/key_import_password_input_hint"
                         android:textSize="16sp"
                         android:padding="16dp"/>
             </android.support.design.widget.TextInputLayout>
 
 
             <android.support.design.widget.TextInputLayout
+                    android:hint="@string/key_input_key_hint"
                     android:layout_below="@id/password_container"
-
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
                 <android.support.design.widget.TextInputEditText
@@ -80,7 +80,6 @@
                         android:layout_height="wrap_content"
                         android:layout_centerHorizontal="true"
                         android:fontFamily="sans-serif"
-                        android:hint="@string/key_input_key_hint"
                         android:textSize="16sp"
                         android:padding="16dp"/>
             </android.support.design.widget.TextInputLayout>

--- a/app/src/main/res/layout/activity_relay.xml
+++ b/app/src/main/res/layout/activity_relay.xml
@@ -13,6 +13,7 @@
 
     <android.support.design.widget.TextInputLayout
             android:id="@+id/account_name_container"
+            android:hint="@string/transaction_to_use_hint"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
         <android.support.design.widget.TextInputEditText
@@ -21,7 +22,6 @@
                 android:layout_height="wrap_content"
                 android:layout_centerHorizontal="true"
                 android:fontFamily="sans-serif"
-                android:hint="@string/transaction_to_use_hint"
                 android:textSize="16sp"
                 android:padding="16dp"/>
     </android.support.design.widget.TextInputLayout>

--- a/app/src/main/res/layout/activity_request.xml
+++ b/app/src/main/res/layout/activity_request.xml
@@ -38,6 +38,7 @@
     <android.support.design.widget.TextInputLayout
             android:layout_below="@+id/add_value_checkbox"
             android:id="@+id/value_input_layout"
+            android:hint="@string/request_funds_value_hint"
             android:visibility="gone"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
@@ -47,7 +48,6 @@
                 android:layout_height="wrap_content"
                 android:id="@+id/value_input_edittext"
                 android:inputType="numberDecimal"
-                android:hint="@string/request_funds_value_hint"
         />
     </android.support.design.widget.TextInputLayout>
     <TextView

--- a/app/src/main/res/layout/activity_show_qr.xml
+++ b/app/src/main/res/layout/activity_show_qr.xml
@@ -12,23 +12,23 @@
 
     <android.support.design.widget.TextInputLayout
             style="@style/password_textinputlayout"
+            android:hint="@string/input_hint_export_password"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
         <android.support.design.widget.TextInputEditText
                 android:inputType="textPassword"
                 android:id="@+id/password_input"
-                android:hint="Export password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
     </android.support.design.widget.TextInputLayout>
     <android.support.design.widget.TextInputLayout
+            android:hint="@string/input_hint_confirm_export_password"
             style="@style/password_textinputlayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
         <android.support.design.widget.TextInputEditText
                 android:inputType="textPassword"
                 android:id="@+id/password_input_confirmation"
-                android:hint="Confirm export password"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
     </android.support.design.widget.TextInputLayout>
@@ -45,7 +45,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
         <TextView
-                android:text="Confirmation does not match Password"
+                android:text="@string/error_confirmation_does_not_match_password"
                 android:layout_gravity="center_vertical"
                 android:textColor="@color/warning"
                 android:layout_width="wrap_content"
@@ -58,7 +58,7 @@
     </LinearLayout>
 
     <android.support.v7.widget.SwitchCompat
-            android:text="show QR-Code"
+            android:text="@string/show_qr_code"
             android:id="@+id/show_qr_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/dialog_add_reference.xml
+++ b/app/src/main/res/layout/dialog_add_reference.xml
@@ -2,6 +2,7 @@
 <android.support.design.widget.TextInputLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/activity_main"
+        android:hint="@string/input_hint_reference_to_add"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:padding="@dimen/rythm2">
@@ -9,7 +10,6 @@
 
     <android.support.v7.widget.AppCompatEditText
             android:id="@+id/reference_text"
-            android:hint="Reference to add"
             android:lines="1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/hd_derivation_select.xml
+++ b/app/src/main/res/layout/hd_derivation_select.xml
@@ -13,10 +13,10 @@
 
     <android.support.design.widget.TextInputLayout
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:hint="@string/input_hint_derivation_path">
         <android.support.design.widget.TextInputEditText
                 android:id="@+id/derivation_text"
-                android:hint="Derivation path"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,4 +204,13 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="paste_from_clipboard_action">Use it</string>
     <string name="copied_string_warning_title">Warning</string>
     <string name="copied_string_warning_message">Copied details could have been tampered with by other apps. Please verify the details!</string>
+    <string name="input_hint_token_name">Token name</string>
+    <string name="input_hint_token_address">Token address</string>
+    <string name="input_hint_decimals">Decimals</string>
+    <string name="input_hint_export_password">Export password</string>
+    <string name="input_hint_confirm_export_password">Confirm export password</string>
+    <string name="error_confirmation_does_not_match_password">Confirmation does not match Password</string>
+    <string name="show_qr_code">show QR code</string>
+    <string name="input_hint_reference_to_add">Reference to add</string>
+    <string name="input_hint_derivation_path">Derivation path</string>
 </resources>


### PR DESCRIPTION
This PR fixes #108 by moving the hints from edit texts to input layouts
as described in comment 28 in https://issuetracker.google.com/issues/62834931

This PR also extracts some strings.

I could reproduce the NPE by long click on an edit text in the emulator 8.0.0 and select AUTOFILL. The crash did not happen after this fix.