### PR TITLE
7/Add copy actions

### DIFF
--- a/app/src/main/java/org/walleth/activities/EditAccountActivity.kt
+++ b/app/src/main/java/org/walleth/activities/EditAccountActivity.kt
@@ -18,6 +18,7 @@ import org.walleth.data.addressbook.AddressBookEntry
 import org.walleth.data.addressbook.getByAddressAsync
 import org.walleth.data.networks.CurrentAddressProvider
 import org.walleth.data.networks.NetworkDefinitionProvider
+import org.walleth.util.copyToClipboard
 
 class EditAccountActivity : AppCompatActivity() {
 

--- a/app/src/main/java/org/walleth/activities/EditAccountActivity.kt
+++ b/app/src/main/java/org/walleth/activities/EditAccountActivity.kt
@@ -69,6 +69,9 @@ class EditAccountActivity : AppCompatActivity() {
 
 
     override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        R.id.menu_copy -> true.also {
+            copyToClipboard(currentAddressInfo.address, activity_main)
+        }
         R.id.menu_etherscan -> true.also {
             startActivityFromURL(networkDefinitionProvider.value!!.getBlockExplorer().getURLforAddress(currentAddressProvider.getCurrent()))
         }

--- a/app/src/main/java/org/walleth/activities/MainActivity.kt
+++ b/app/src/main/java/org/walleth/activities/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.walleth.activities
 
+import android.app.Activity
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.Observer
 import android.content.*
@@ -14,6 +15,7 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.view.View.INVISIBLE
 import com.github.salomonbrys.kodein.LazyKodein
 import com.github.salomonbrys.kodein.android.appKodein
@@ -24,6 +26,7 @@ import kotlinx.android.synthetic.main.value.*
 import org.json.JSONObject
 import org.kethereum.erc681.isEthereumURLString
 import org.kethereum.erc681.toERC681
+import org.kethereum.model.Address
 import org.ligi.kaxt.recreateWhenPossible
 import org.ligi.kaxt.setVisibility
 import org.ligi.kaxt.startActivityFromClass
@@ -295,6 +298,10 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     }
 
     override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        R.id.menu_copy -> {
+            copyToClipboard(currentAddressProvider.getCurrent(), fab)
+            true
+        }
         R.id.menu_info -> {
             startActivityFromClass(InfoActivity::class.java)
             true
@@ -318,4 +325,14 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         settings.unregisterListener(this)
         super.onDestroy()
     }
+}
+
+fun Activity.copyToClipboard(address: Address, anchor: View) {
+    copyToClipboard("ethereum:${address.hex}", anchor)
+}
+
+fun Activity.copyToClipboard(ethereumString: String, anchor: View) {
+    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.primaryClip = ClipData.newPlainText(getString(R.string.clipboard_copy_name), ethereumString)
+    Snackbar.make(anchor, R.string.copied_to_clipboard, Snackbar.LENGTH_LONG).show()
 }

--- a/app/src/main/java/org/walleth/activities/MainActivity.kt
+++ b/app/src/main/java/org/walleth/activities/MainActivity.kt
@@ -1,6 +1,5 @@
 package org.walleth.activities
 
-import android.app.Activity
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.Observer
 import android.content.*
@@ -15,7 +14,6 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.view.Menu
 import android.view.MenuItem
-import android.view.View
 import android.view.View.INVISIBLE
 import com.github.salomonbrys.kodein.LazyKodein
 import com.github.salomonbrys.kodein.android.appKodein
@@ -26,7 +24,6 @@ import kotlinx.android.synthetic.main.value.*
 import org.json.JSONObject
 import org.kethereum.erc681.isEthereumURLString
 import org.kethereum.erc681.toERC681
-import org.kethereum.model.Address
 import org.ligi.kaxt.recreateWhenPossible
 import org.ligi.kaxt.setVisibility
 import org.ligi.kaxt.startActivityFromClass
@@ -44,6 +41,7 @@ import org.walleth.data.transactions.TransactionEntity
 import org.walleth.ui.TransactionAdapterDirection.INCOMING
 import org.walleth.ui.TransactionAdapterDirection.OUTGOING
 import org.walleth.ui.TransactionRecyclerAdapter
+import org.walleth.util.copyToClipboard
 import java.math.BigInteger.ZERO
 
 private const val KEY_LAST_PASTED_DATA: String = "LAST_PASTED_DATA"
@@ -80,7 +78,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         if (clipboard.hasPrimaryClip()) {
             val item = clipboard.primaryClip.getItemAt(0).text?.toString()
             val erc681 = item?.toERC681()
-            if (erc681?.valid == true && erc681?.address != null && item != lastPastedData && item != "ethereum:${currentAddressProvider.getCurrent().hex}") {
+            if (erc681?.valid == true && erc681?.address != null && item != lastPastedData && item != "ethereum:${currentAddressProvider.value?.hex}") {
                 Snackbar.make(fab, R.string.paste_from_clipboard, Snackbar.LENGTH_INDEFINITE)
                         .addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
                             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
@@ -325,14 +323,4 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         settings.unregisterListener(this)
         super.onDestroy()
     }
-}
-
-fun Activity.copyToClipboard(address: Address, view: View) {
-    copyToClipboard("ethereum:${address.hex}", view)
-}
-
-fun Activity.copyToClipboard(ethereumString: String, view: View) {
-    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    clipboard.primaryClip = ClipData.newPlainText(getString(R.string.clipboard_copy_name), ethereumString)
-    Snackbar.make(view, R.string.copied_to_clipboard, Snackbar.LENGTH_LONG).show()
 }

--- a/app/src/main/java/org/walleth/activities/MainActivity.kt
+++ b/app/src/main/java/org/walleth/activities/MainActivity.kt
@@ -80,7 +80,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         if (clipboard.hasPrimaryClip()) {
             val item = clipboard.primaryClip.getItemAt(0).text?.toString()
             val erc681 = item?.toERC681()
-            if (erc681?.valid == true && erc681?.address != null && item != lastPastedData) {
+            if (erc681?.valid == true && erc681?.address != null && item != lastPastedData && item != "ethereum:${currentAddressProvider.getCurrent().hex}") {
                 Snackbar.make(fab, R.string.paste_from_clipboard, Snackbar.LENGTH_INDEFINITE)
                         .addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
                             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
@@ -327,12 +327,12 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     }
 }
 
-fun Activity.copyToClipboard(address: Address, anchor: View) {
-    copyToClipboard("ethereum:${address.hex}", anchor)
+fun Activity.copyToClipboard(address: Address, view: View) {
+    copyToClipboard("ethereum:${address.hex}", view)
 }
 
-fun Activity.copyToClipboard(ethereumString: String, anchor: View) {
+fun Activity.copyToClipboard(ethereumString: String, view: View) {
     val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     clipboard.primaryClip = ClipData.newPlainText(getString(R.string.clipboard_copy_name), ethereumString)
-    Snackbar.make(anchor, R.string.copied_to_clipboard, Snackbar.LENGTH_LONG).show()
+    Snackbar.make(view, R.string.copied_to_clipboard, Snackbar.LENGTH_LONG).show()
 }

--- a/app/src/main/java/org/walleth/activities/RequestActivity.kt
+++ b/app/src/main/java/org/walleth/activities/RequestActivity.kt
@@ -1,11 +1,7 @@
 package org.walleth.activities
 
-import android.content.ClipData
-import android.content.ClipboardManager
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.support.design.widget.Snackbar
 import android.support.v7.app.AppCompatActivity
 import android.text.method.LinkMovementMethod
 import android.view.Menu
@@ -27,6 +23,7 @@ import org.walleth.data.tokens.CurrentTokenProvider
 import org.walleth.data.tokens.isETH
 import org.walleth.functions.extractValueForToken
 import org.walleth.functions.setQRCode
+import org.walleth.util.copyToClipboard
 
 class RequestActivity : AppCompatActivity() {
 
@@ -46,7 +43,7 @@ class RequestActivity : AppCompatActivity() {
         refreshQR()
 
 
-        val initText = getString(if (networkDefinitionProvider.getCurrent().isNoTestNet() ) {
+        val initText = getString(if (networkDefinitionProvider.getCurrent().isNoTestNet()) {
             R.string.request_hint_no_test_net
         } else {
             R.string.request_hint_test_net
@@ -74,7 +71,7 @@ class RequestActivity : AppCompatActivity() {
 
             if (add_value_checkbox.isChecked) {
                 try {
-                    currentERC67String = ERC681(address = relevantAddress.hex,value =value_input_edittext.text.toString().extractValueForToken(currentToken) ).generateURL()
+                    currentERC67String = ERC681(address = relevantAddress.hex, value = value_input_edittext.text.toString().extractValueForToken(currentToken)).generateURL()
                 } catch (e: NumberFormatException) {
                 }
             }

--- a/app/src/main/java/org/walleth/activities/RequestActivity.kt
+++ b/app/src/main/java/org/walleth/activities/RequestActivity.kt
@@ -114,9 +114,7 @@ class RequestActivity : AppCompatActivity() {
             true
         }
         R.id.menu_copy -> {
-            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            clipboard.primaryClip = ClipData.newPlainText(getString(R.string.clipboard_copy_name), currentERC67String)
-            Snackbar.make(receive_qrcode, R.string.copied_to_clipboard, Snackbar.LENGTH_LONG).show()
+            copyToClipboard(currentERC67String, receive_qrcode)
             true
         }
         android.R.id.home -> {

--- a/app/src/main/java/org/walleth/util/Clipboard.kt
+++ b/app/src/main/java/org/walleth/util/Clipboard.kt
@@ -1,0 +1,21 @@
+package org.walleth.util
+
+import android.app.Activity
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.support.design.widget.Snackbar
+import android.view.View
+import org.kethereum.model.Address
+import org.walleth.R
+
+
+fun Activity.copyToClipboard(address: Address, view: View) {
+    copyToClipboard("ethereum:${address.hex}", view)
+}
+
+fun Activity.copyToClipboard(ethereumString: String, view: View) {
+    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.primaryClip = ClipData.newPlainText(getString(R.string.clipboard_copy_name), ethereumString)
+    Snackbar.make(view, R.string.copied_to_clipboard, Snackbar.LENGTH_LONG).show()
+}

--- a/app/src/main/res/menu/menu_edit.xml
+++ b/app/src/main/res/menu/menu_edit.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-            android:title="@string/open_in_etherscan"
-            android:id="@+id/menu_etherscan"/>
+        android:id="@+id/menu_copy"
+        android:icon="@drawable/ic_content_copy"
+        android:title="@string/copy"
+        app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/menu_etherscan"
+        android:title="@string/open_in_etherscan"/>
 </menu>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-            android:title="Info"
-            android:id="@+id/menu_info"
-            android:icon="@drawable/ic_action_info_outline"
-            app:showAsAction="ifRoom"
-    />
+        android:id="@+id/menu_copy"
+        android:icon="@drawable/ic_content_copy"
+        android:title="@string/copy"
+        app:showAsAction="ifRoom"
+        />
+    <item
+        android:id="@+id/menu_info"
+        android:icon="@drawable/ic_action_info_outline"
+        android:title="@string/info"
+        app:showAsAction="ifRoom"
+        />
 </menu>

--- a/app/src/main/res/menu/menu_request.xml
+++ b/app/src/main/res/menu/menu_request.xml
@@ -7,7 +7,7 @@
             app:showAsAction="ifRoom"
     />
     <item
-            android:title="Share"
+            android:title="@string/share"
             android:id="@+id/menu_share"
             android:icon="@drawable/ic_share_24dp"
             app:showAsAction="ifRoom"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,8 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="input_hint_notes">notes</string>
     <string name="input_hint_account_name">account name</string>
     <string name="please_enter_name">Please enter a name</string>
+    <string name="info">About</string>
+    <string name="copy">Copy</string>
     <string name="share">Share</string>
     <string name="print">Print</string>
     <string name="paper_wallet_title">WALLΞTH Paper Ethereum Wallet</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="input_hint_notes">notes</string>
     <string name="input_hint_account_name">account name</string>
     <string name="please_enter_name">Please enter a name</string>
-    <string name="info">About</string>
+    <string name="info">Info</string>
     <string name="copy">Copy</string>
     <string name="share">Share</string>
     <string name="print">Print</string>


### PR DESCRIPTION
This PR adds copy action to the main activity and the edit account screen.

It refactors the code from the request activity. The snackbar for copied ethereum addresses is adapted to ignore the current address.

This fixes #7 