### PR TITLE
178/replace ethereum scheme string with ERC681

### DIFF
--- a/app/src/main/java/org/walleth/activities/CreateTransactionActivity.kt
+++ b/app/src/main/java/org/walleth/activities/CreateTransactionActivity.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.async
 import org.kethereum.erc681.ERC681
+import org.kethereum.erc681.generateURL
 import org.kethereum.erc681.isEthereumURLString
 import org.kethereum.erc681.parseERC681
 import org.kethereum.functions.createTokenTransferTransactionInput
@@ -318,7 +319,7 @@ class CreateTransactionActivity : AppCompatActivity() {
     private fun setToFromURL(uri: String?, fromUser: Boolean) {
         if (uri != null) {
 
-            currentERC67String = if (uri.startsWith("0x")) "ethereum:$uri" else uri
+            currentERC67String = if (uri.startsWith("0x")) ERC681(address = uri).generateURL() else uri
 
             if (parseERC681(currentERC67String!!).valid) {
                 val erc681 = parseERC681(currentERC67String!!)

--- a/app/src/main/java/org/walleth/activities/MainActivity.kt
+++ b/app/src/main/java/org/walleth/activities/MainActivity.kt
@@ -22,6 +22,8 @@ import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.activity_main_in_drawer_container.*
 import kotlinx.android.synthetic.main.value.*
 import org.json.JSONObject
+import org.kethereum.erc681.ERC681
+import org.kethereum.erc681.generateURL
 import org.kethereum.erc681.isEthereumURLString
 import org.kethereum.erc681.toERC681
 import org.ligi.kaxt.recreateWhenPossible
@@ -78,7 +80,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
         if (clipboard.hasPrimaryClip()) {
             val item = clipboard.primaryClip.getItemAt(0).text?.toString()
             val erc681 = item?.toERC681()
-            if (erc681?.valid == true && erc681?.address != null && item != lastPastedData && item != "ethereum:${currentAddressProvider.value?.hex}") {
+            if (erc681?.valid == true && erc681?.address != null && item != lastPastedData && item != currentAddressProvider.value?.hex.let { ERC681(address = it).generateURL() }) {
                 Snackbar.make(fab, R.string.paste_from_clipboard, Snackbar.LENGTH_INDEFINITE)
                         .addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
                             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
@@ -130,7 +132,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                 }
 
                 scanResult.startsWith("0x") -> {
-                    startActivity(getEthereumViewIntent("ethereum:" + scanResult))
+                    startActivity(getEthereumViewIntent(ERC681(address = scanResult).generateURL()))
                 }
 
                 else -> {

--- a/app/src/main/java/org/walleth/util/Clipboard.kt
+++ b/app/src/main/java/org/walleth/util/Clipboard.kt
@@ -6,12 +6,14 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.support.design.widget.Snackbar
 import android.view.View
+import org.kethereum.erc681.ERC681
+import org.kethereum.erc681.generateURL
 import org.kethereum.model.Address
 import org.walleth.R
 
 
 fun Activity.copyToClipboard(address: Address, view: View) {
-    copyToClipboard("ethereum:${address.hex}", view)
+    copyToClipboard(ERC681(address = address.hex).generateURL(), view)
 }
 
 fun Activity.copyToClipboard(ethereumString: String, view: View) {


### PR DESCRIPTION
This PR replaces all use of "ethereum:" with the ERC681 object and the generateUrl function.

fixes #178 