### PR TITLE
182/update etherscan endpoints

### DIFF
--- a/app/src/main/java/org/walleth/data/blockexplorer/EtherscanBlockExplorer.kt
+++ b/app/src/main/java/org/walleth/data/blockexplorer/EtherscanBlockExplorer.kt
@@ -4,7 +4,7 @@ import org.kethereum.model.Address
 
 class EtherscanBlockExplorer(private val prefix: String) {
 
-    val baseAPIURL by lazy { "https://" + (if (prefix.isBlank()) "api" else prefix) + ".etherscan.io" }
+    val baseAPIURL by lazy { "https://" + (if (prefix.isBlank()) "api" else "api-$prefix") + ".etherscan.io" }
     private val baseURL by lazy { "https://" + (if (prefix.isBlank()) "" else (prefix + ".")) + "etherscan.io" }
 
     fun getURLforAddress(address: Address) = "$baseURL/address/${address.hex}"


### PR DESCRIPTION
updating the baseAPIURL to reflect Etherscan's new API endpoints as documented [here](https://etherscancom.freshdesk.com/support/solutions/articles/35000051806-change-of-testnet-api-service-endpoint-url) and in #182 