### PR TITLE
190/Add function call via FourByteDirectory in ViewTransactionActivity

### DIFF
--- a/app/src/androidTest/java/org/walleth/infrastructure/TestApp.kt
+++ b/app/src/androidTest/java/org/walleth/infrastructure/TestApp.kt
@@ -75,10 +75,14 @@ class TestApp : App() {
         val networkDefinitionProvider = NetworkDefinitionProvider(mySettings)
         val currentTokenProvider = CurrentTokenProvider(networkDefinitionProvider)
 
-        val contractFunctionTextSignature = "aFunctionCall(address)"
+        val contractFunctionTextSignature1 = "aFunctionCall1(address)"
+        val contractFunctionTextSignature2 = "aFunctionCall2(address)"
         val testFourByteDirectory = mock(FourByteDirectory::class.java).apply {
-            `when`(getSignatureFor(any())).then { invocation ->
-                ContractFunction(invocation.arguments[0] as String, textSignature = contractFunctionTextSignature)
+            `when`(getSignaturesFor(any())).then { invocation ->
+                listOf(
+                        ContractFunction(invocation.arguments[0] as String, textSignature = contractFunctionTextSignature1),
+                        ContractFunction(invocation.arguments[0] as String, textSignature = contractFunctionTextSignature2)
+                )
             }
         }
         lateinit var testDatabase: AppDatabase

--- a/app/src/androidTest/java/org/walleth/infrastructure/TestApp.kt
+++ b/app/src/androidTest/java/org/walleth/infrastructure/TestApp.kt
@@ -10,6 +10,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.walleth.App
+import org.walleth.contracts.FourByteDirectory
 import org.walleth.data.AppDatabase
 import org.walleth.data.DEFAULT_GAS_PRICE
 import org.walleth.data.config.Settings
@@ -21,6 +22,7 @@ import org.walleth.data.networks.RINKEBY_CHAIN_ID
 import org.walleth.data.syncprogress.SyncProgressProvider
 import org.walleth.data.syncprogress.WallethSyncProgress
 import org.walleth.data.tokens.CurrentTokenProvider
+import org.walleth.kethereum.model.ContractFunction
 import org.walleth.testdata.DefaultCurrentAddressProvider
 import org.walleth.testdata.FixedValueExchangeProvider
 import org.walleth.testdata.TestKeyStore
@@ -47,6 +49,7 @@ class TestApp : App() {
         bind<NetworkDefinitionProvider>() with singleton { networkDefinitionProvider }
         bind<CurrentTokenProvider>() with singleton { currentTokenProvider }
         bind<AppDatabase>() with singleton { testDatabase }
+        bind<FourByteDirectory>() with singleton { testFourByteDirectory }
     }
 
     override fun executeCodeWeWillIgnoreInTests() = Unit
@@ -71,6 +74,13 @@ class TestApp : App() {
         val currentAddressProvider = DefaultCurrentAddressProvider(mySettings)
         val networkDefinitionProvider = NetworkDefinitionProvider(mySettings)
         val currentTokenProvider = CurrentTokenProvider(networkDefinitionProvider)
+
+        val contractFunctionTextSignature = "aFunctionCall(address)"
+        val testFourByteDirectory = mock(FourByteDirectory::class.java).apply {
+            `when`(getSignatureFor(any())).then { invocation ->
+                ContractFunction(invocation.arguments[0] as String, textSignature = contractFunctionTextSignature)
+            }
+        }
         lateinit var testDatabase: AppDatabase
         fun resetDB(context: Context) {
             testDatabase = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()

--- a/app/src/androidTest/java/org/walleth/tests/TheTransactionActivity.kt
+++ b/app/src/androidTest/java/org/walleth/tests/TheTransactionActivity.kt
@@ -5,6 +5,7 @@ import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.espresso.matcher.ViewMatchers.withText
+import org.hamcrest.Matchers.*
 import org.junit.Rule
 import org.junit.Test
 import org.kethereum.model.ChainDefinition
@@ -86,7 +87,8 @@ class TheTransactionActivity {
 
         rule.launchActivity(InstrumentationRegistry.getTargetContext().getTransactionActivityIntentForHash(transaction.txHash!!))
 
-        onView(withId(R.id.function_call)).check(matches(withText(TestApp.contractFunctionTextSignature)))
+        onView(withId(R.id.function_call)).check(matches(withText(
+                allOf(containsString(TestApp.contractFunctionTextSignature1), containsString(TestApp.contractFunctionTextSignature2)))))
     }
 
 

--- a/app/src/androidTest/java/org/walleth/tests/TheTransactionActivity.kt
+++ b/app/src/androidTest/java/org/walleth/tests/TheTransactionActivity.kt
@@ -17,6 +17,7 @@ import org.walleth.data.ETH_IN_WEI
 import org.walleth.data.transactions.TransactionState
 import org.walleth.data.transactions.toEntity
 import org.walleth.infrastructure.TestApp
+import org.walleth.khex.hexToByteArray
 import org.walleth.testdata.DEFAULT_TEST_ADDRESS
 import org.walleth.testdata.Room77
 import org.walleth.testdata.ShapeShift
@@ -70,6 +71,22 @@ class TheTransactionActivity {
 
         onView(withId(R.id.from_to_title)).check(matches(withText(R.string.transaction_from_label)))
         onView(withId(R.id.from_to)).check(matches(withText("ShapeShift")))
+    }
+
+
+    @Test
+    fun showsTheCorrectMethodSignature() {
+        val transaction = DEFAULT_TX.copy(from = ShapeShift, to = DEFAULT_TEST_ADDRESS,
+                input = "0xdeafbeef000000000000000000000000f44f28b5ca7808b9ad782c759ab8efb041de64d2".hexToByteArray().toList())
+
+        TestApp.testDatabase.runInTransaction {
+            TestApp.testDatabase.addressBook.addTestAddresses()
+            TestApp.testDatabase.transactions.upsert(transaction.toEntity(null, TransactionState()))
+        }
+
+        rule.launchActivity(InstrumentationRegistry.getTargetContext().getTransactionActivityIntentForHash(transaction.txHash!!))
+
+        onView(withId(R.id.function_call)).check(matches(withText(TestApp.contractFunctionTextSignature)))
     }
 
 

--- a/app/src/main/java/org/walleth/App.kt
+++ b/app/src/main/java/org/walleth/App.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.experimental.async
 import okhttp3.OkHttpClient
 import org.kethereum.model.Address
 import org.ligi.tracedroid.TraceDroid
+import org.walleth.contracts.FourByteDirectory
+import org.walleth.contracts.FourByteDirectoryImpl
 import org.walleth.core.EtherScanService
 import org.walleth.core.TransactionNotificationService
 import org.walleth.data.AppDatabase
@@ -74,6 +76,7 @@ open class App : MultiDexApplication(), KodeinAware {
             bind<AppDatabase>() with singleton { Room.databaseBuilder(applicationContext, AppDatabase::class.java, "maindb").build() }
             bind<NetworkDefinitionProvider>() with singleton { NetworkDefinitionProvider(instance()) }
             bind<CurrentAddressProvider>() with singleton { InitializingCurrentAddressProvider(gethBackedWallethKeyStore, instance(), instance(), applicationContext) }
+            bind<FourByteDirectory>() with singleton { FourByteDirectoryImpl(instance()) }
         }
     }
 
@@ -151,11 +154,12 @@ open class App : MultiDexApplication(), KodeinAware {
         try {
             startService(Intent(this, EtherScanService::class.java))
             startService(Intent(this, TransactionNotificationService::class.java))
-        } catch (e: IllegalStateException) {  }
+        } catch (e: IllegalStateException) {
+        }
     }
 
     companion object {
-        val postInitCallbacks = mutableListOf<()->Unit>()
+        val postInitCallbacks = mutableListOf<() -> Unit>()
 
         fun applyNightMode(settings: Settings) {
             @AppCompatDelegate.NightMode val nightMode = settings.getNightMode()

--- a/app/src/main/java/org/walleth/App.kt
+++ b/app/src/main/java/org/walleth/App.kt
@@ -76,7 +76,7 @@ open class App : MultiDexApplication(), KodeinAware {
             bind<AppDatabase>() with singleton { Room.databaseBuilder(applicationContext, AppDatabase::class.java, "maindb").build() }
             bind<NetworkDefinitionProvider>() with singleton { NetworkDefinitionProvider(instance()) }
             bind<CurrentAddressProvider>() with singleton { InitializingCurrentAddressProvider(gethBackedWallethKeyStore, instance(), instance(), applicationContext) }
-            bind<FourByteDirectory>() with singleton { FourByteDirectoryImpl(instance()) }
+            bind<FourByteDirectory>() with singleton { FourByteDirectoryImpl(instance(), applicationContext) }
         }
     }
 

--- a/app/src/main/java/org/walleth/activities/ViewTransactionActivity.kt
+++ b/app/src/main/java/org/walleth/activities/ViewTransactionActivity.kt
@@ -22,6 +22,7 @@ import org.kethereum.functions.encodeRLP
 import org.ligi.kaxt.setVisibility
 import org.ligi.kaxt.startActivityFromURL
 import org.walleth.R
+import org.walleth.contracts.FourByteDirectory
 import org.walleth.data.AppDatabase
 import org.walleth.data.addressbook.resolveNameAsync
 import org.walleth.data.networks.CurrentAddressProvider
@@ -39,11 +40,12 @@ fun Context.getTransactionActivityIntentForHash(hex: String)
 }
 
 class ViewTransactionActivity : AppCompatActivity() {
-
-    private val appDatabase: AppDatabase by LazyKodein(appKodein).instance()
-    private val currentAddressProvider: CurrentAddressProvider by LazyKodein(appKodein).instance()
-    private val networkDefinitionProvider: NetworkDefinitionProvider by LazyKodein(appKodein).instance()
+    val lazyKodein = LazyKodein(appKodein)
+    private val appDatabase: AppDatabase by lazyKodein.instance()
+    private val currentAddressProvider: CurrentAddressProvider by lazyKodein.instance()
+    private val networkDefinitionProvider: NetworkDefinitionProvider by lazyKodein.instance()
     private var txEntity: TransactionEntity? = null
+    private val fourByteDirectory: FourByteDirectory by lazyKodein.instance()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -136,6 +138,19 @@ class ViewTransactionActivity : AppCompatActivity() {
                     message += "\nError:" + error
                 }
                 details.text = message
+
+                transaction.input.let {
+                    if (it.size >= 4) {
+                        function_call_label.visibility = View.VISIBLE
+                        function_call.visibility = View.VISIBLE
+                        async(UI) {
+                            val result = async(CommonPool) {
+                                fourByteDirectory.getSignatureFor(it.subList(0, 4).toHexString())
+                            }.await()
+                            function_call.text = result?.textSignature ?: "-"
+                        }
+                    }
+                }
             }
         })
 

--- a/app/src/main/java/org/walleth/activities/ViewTransactionActivity.kt
+++ b/app/src/main/java/org/walleth/activities/ViewTransactionActivity.kt
@@ -144,10 +144,16 @@ class ViewTransactionActivity : AppCompatActivity() {
                         function_call_label.visibility = View.VISIBLE
                         function_call.visibility = View.VISIBLE
                         async(UI) {
-                            val result = async(CommonPool) {
-                                fourByteDirectory.getSignatureFor(it.subList(0, 4).toHexString())
+                            val signatures = async(CommonPool) {
+                                fourByteDirectory.getSignaturesFor(it.subList(0, 4).toHexString())
                             }.await()
-                            function_call.text = result?.textSignature ?: "-"
+                            function_call.text = if (signatures.isNotEmpty()) {
+                                signatures.joinToString(
+                                        separator = " ${getString(R.string.or)}\n",
+                                        transform = { sig -> sig.textSignature ?: sig.hexSignature })
+                            } else {
+                                "-"
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/org/walleth/contracts/FourByteDirectory.kt
+++ b/app/src/main/java/org/walleth/contracts/FourByteDirectory.kt
@@ -1,0 +1,50 @@
+package org.walleth.contracts
+
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONException
+import org.json.JSONObject
+import org.walleth.kethereum.model.ContractFunction
+import java.io.IOException
+
+interface FourByteDirectory {
+    fun getSignatureFor(hex: String): ContractFunction?
+}
+
+class FourByteDirectoryImpl(private val okHttpClient: OkHttpClient) : FourByteDirectory {
+    private val baseURL = "https://www.4byte.directory/api/v1"
+
+    override fun getSignatureFor(hex: String): ContractFunction? {
+        val urlString = "$baseURL/signatures/?hex_signature=$hex"
+        val url = Request.Builder().url(urlString).build()
+        val newCall: Call = okHttpClient.newCall(url)
+
+        try {
+            val resultString = newCall.execute().body().use { it?.string() }
+            return resultString?.fourByteResultToSingleContractFunction()
+
+        } catch (ioe: IOException) {
+            ioe.printStackTrace()
+        } catch (jsonException: JSONException) {
+            jsonException.printStackTrace()
+        }
+        return null
+    }
+}
+
+fun String.fourByteResultToSingleContractFunction(): ContractFunction? {
+    return JSONObject(this).let {
+        val count = it.getInt("count")
+        if (count >= 1) {
+            it.getJSONArray("results").get(0) as JSONObject
+        } else {
+            null
+        }
+    }?.let {
+        ContractFunction(
+                textSignature = it.getString("text_signature"),
+                hexSignature = it.getString("hex_signature")
+        )
+    }
+}

--- a/app/src/main/java/org/walleth/contracts/FourByteDirectory.kt
+++ b/app/src/main/java/org/walleth/contracts/FourByteDirectory.kt
@@ -1,50 +1,75 @@
 package org.walleth.contracts
 
+import android.content.Context
 import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import org.walleth.functions.JSONObjectIterator
 import org.walleth.kethereum.model.ContractFunction
+import org.walleth.util.FileBackedStore
 import java.io.IOException
 
 interface FourByteDirectory {
-    fun getSignatureFor(hex: String): ContractFunction?
+    fun getSignaturesFor(hex: String): List<ContractFunction>
 }
 
-class FourByteDirectoryImpl(private val okHttpClient: OkHttpClient) : FourByteDirectory {
+class FourByteDirectoryImpl(private val okHttpClient: OkHttpClient, context: Context) : FourByteDirectory {
+    val signatureStore = FileBackedStore(context.getDir("funsignatures", Context.MODE_PRIVATE))
     private val baseURL = "https://www.4byte.directory/api/v1"
 
-    override fun getSignatureFor(hex: String): ContractFunction? {
+    override fun getSignaturesFor(hex: String): List<ContractFunction> {
+        return try {
+            signatureStore.get(hex).map {
+                ContractFunction(
+                        textSignature = it,
+                        hexSignature = hex
+                )
+            }
+        } catch (exception: IOException) {
+            fetchAndStore(hex)
+        }
+    }
+
+    private fun fetchAndStore(hex: String): ArrayList<ContractFunction> {
+        val signatures = ArrayList<ContractFunction>()
         val urlString = "$baseURL/signatures/?hex_signature=$hex"
         val url = Request.Builder().url(urlString).build()
         val newCall: Call = okHttpClient.newCall(url)
 
         try {
             val resultString = newCall.execute().body().use { it?.string() }
-            return resultString?.fourByteResultToSingleContractFunction()
+            resultString?.fourByteResultToContractFunctions()?.let {
+                signatures.addAll(it)
+            }
 
         } catch (ioe: IOException) {
             ioe.printStackTrace()
         } catch (jsonException: JSONException) {
             jsonException.printStackTrace()
         }
-        return null
+        return signatures
     }
-}
 
-fun String.fourByteResultToSingleContractFunction(): ContractFunction? {
-    return JSONObject(this).let {
-        val count = it.getInt("count")
-        if (count >= 1) {
-            it.getJSONArray("results").get(0) as JSONObject
-        } else {
-            null
+    fun String.fourByteResultToContractFunctions(): List<ContractFunction> {
+        val signatures = ArrayList<ContractFunction>()
+        JSONObject(this).let {
+            val count = it.getInt("count")
+            if (count >= 1) {
+                it.getJSONArray("results").JSONObjectIterator().forEach {
+                    val textSignature = it.getString("text_signature")
+                    val hexSignature = it.getString("hex_signature")
+                    signatureStore.upsert(hexSignature, textSignature)
+
+                    signatures.add(ContractFunction(
+                            textSignature = textSignature,
+                            hexSignature = hexSignature))
+                }
+            }
         }
-    }?.let {
-        ContractFunction(
-                textSignature = it.getString("text_signature"),
-                hexSignature = it.getString("hex_signature")
-        )
+        return signatures
     }
+
 }

--- a/app/src/main/java/org/walleth/data/AppDatabase.java
+++ b/app/src/main/java/org/walleth/data/AppDatabase.java
@@ -12,7 +12,7 @@ import org.walleth.data.tokens.TokenDAO;
 import org.walleth.data.transactions.TransactionDAO;
 import org.walleth.data.transactions.TransactionEntity;
 
-@Database(entities = {AddressBookEntry.class, Token.class, Balance.class, TransactionEntity.class}, version = 1)
+@Database(entities = {AddressBookEntry.class, Token.class, Balance.class, TransactionEntity.class}, version = 2)
 @TypeConverters({RoomTypeConverters.class})
 public abstract class AppDatabase extends RoomDatabase {
 

--- a/app/src/main/java/org/walleth/data/AppDatabase.java
+++ b/app/src/main/java/org/walleth/data/AppDatabase.java
@@ -12,7 +12,7 @@ import org.walleth.data.tokens.TokenDAO;
 import org.walleth.data.transactions.TransactionDAO;
 import org.walleth.data.transactions.TransactionEntity;
 
-@Database(entities = {AddressBookEntry.class, Token.class, Balance.class, TransactionEntity.class}, version = 2)
+@Database(entities = {AddressBookEntry.class, Token.class, Balance.class, TransactionEntity.class}, version = 1)
 @TypeConverters({RoomTypeConverters.class})
 public abstract class AppDatabase extends RoomDatabase {
 

--- a/app/src/main/java/org/walleth/functions/JSON.kt
+++ b/app/src/main/java/org/walleth/functions/JSON.kt
@@ -1,0 +1,7 @@
+package org.walleth.functions
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+fun JSONArray.JSONObjectIterator(): Iterator<JSONObject>
+        = (0 until length()).asSequence().map { get(it) as JSONObject }.iterator()

--- a/app/src/main/java/org/walleth/kethereum/model/ContractFunction.kt
+++ b/app/src/main/java/org/walleth/kethereum/model/ContractFunction.kt
@@ -1,0 +1,7 @@
+package org.walleth.kethereum.model
+
+data class ContractFunction(
+        val hexSignature: String,
+        val textSignature: String? = null,
+        val name: String? = null,
+        val arguments: List<String>? = null)

--- a/app/src/main/java/org/walleth/util/FileBackedStore.kt
+++ b/app/src/main/java/org/walleth/util/FileBackedStore.kt
@@ -1,0 +1,28 @@
+package org.walleth.util
+
+import java.io.File
+
+private fun semicolonSeparatedSet(file: File) = file.readText().split(";").toHashSet()
+
+class FileBackedStore(private val storeDir: File) {
+
+    fun upsert(signatureHash: String, signatureText: String): Boolean {
+        val file = File(storeDir, signatureHash)
+        val isNewEntry = !file.exists()
+        return isNewEntry.also {
+            val res = if (isNewEntry) {
+                HashSet()
+            } else {
+                semicolonSeparatedSet(file)
+            }
+            res.add(signatureText)
+            file.writeText(res.joinToString(";"))
+        }
+    }
+
+    fun get(signatureHash: String) = semicolonSeparatedSet(toFile(signatureHash))
+    fun has(signatureHash: String) = toFile(signatureHash).exists()
+    fun all() = storeDir.list().toList()
+    private fun toFile(signatureHash: String) = File(storeDir, signatureHash)
+
+}

--- a/app/src/main/res/layout/activity_view_transaction.xml
+++ b/app/src/main/res/layout/activity_view_transaction.xml
@@ -60,6 +60,23 @@
 
             </LinearLayout>
             <TextView
+                android:id="@+id/function_call_label"
+                android:text="@string/function_call"
+                android:visibility="gone"
+                android:fontFamily="sans-serif"
+                android:textSize="18dp"
+                android:paddingBottom="8dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+            <TextView
+                android:id="@+id/function_call"
+                android:visibility="gone"
+                android:paddingLeft="8dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+
+            <TextView
                     android:text="Nonce:"
                     android:fontFamily="sans-serif"
                     android:textSize="18dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,4 +218,5 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="create_tx_negative_token_balance">You have less tokens than you want to send. However, some tokens allow to do that. Do you want to continue?</string>
     <string name="create_tx_zero_amount">The amount is set to ZERO ether. Do you want to continue?</string>
     <string name="function_call">Function call:</string>
+    <string name="or">or</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,4 +215,5 @@ Unfortunately there is no faucet for the test-net. So if you want to try out thi
     <string name="show_qr_code">show QR code</string>
     <string name="input_hint_reference_to_add">Reference to add</string>
     <string name="input_hint_derivation_path">Derivation path</string>
+    <string name="function_call">Function call:</string>
 </resources>


### PR DESCRIPTION
This PR adds a text field for transactions that might be a function call to a contract.

If the service 4byte.directory can resolve the hex signature of the function call the text signatures are shown, if not a dash "-" is shown.

Fixes #190 

![screenshot_1519420936](https://user-images.githubusercontent.com/1449049/36619288-9e46976a-18ee-11e8-8f2b-ecf2c7059761.png)

