### PR TITLE
Fix #201 - Apply workaround for slow camera preview

### DIFF
--- a/app/src/main/java/org/walleth/activities/qrscan/Videographer.kt
+++ b/app/src/main/java/org/walleth/activities/qrscan/Videographer.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.graphics.ImageFormat
 import android.graphics.SurfaceTexture
 import android.hardware.Camera
+import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import android.view.Surface
@@ -132,6 +133,11 @@ class Videographer(val activity: Activity) {
         val focusMode = Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE
         if (parameters.supportedFocusModes.contains(focusMode)) {
             parameters.focusMode = focusMode
+        }
+
+        if ("Nexus 4".equals(Build.MODEL)) {
+            //Workaround for slow camera preview on Nexus 4
+            parameters.setRecordingHint(true)
         }
 
         camera.parameters = parameters


### PR DESCRIPTION
Fix for #201. This PR applies the workaround suggested by [Stack Overflow](https://stackoverflow.com/questions/14131900/extreme-camera-lag-on-nexus-4) to improve the frame rate of camera.

Tested on my own Nexus 4 and it improves the frame rate.

Thanks!