### PR TITLE
Fix token layout bug - closes #210

### DIFF
--- a/app/src/main/res/layout/token_list_item.xml
+++ b/app/src/main/res/layout/token_list_item.xml
@@ -37,7 +37,7 @@
                       android:id="@+id/token_name"
                       android:fontFamily="sans-serif"
                       android:layout_alignParentRight="true"
-                      tools:text="Ether"/>
+                      tools:text="Etheraaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/>
 
             <TextView android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
@@ -65,6 +65,9 @@
                   android:padding="8dp"
                   android:fontFamily="sans-serif-condensed"
                   android:layout_alignParentRight="true"
+                  android:lines="1"
+                  android:ellipsize="end"
+                  android:maxWidth="128dp"
                   tools:text="ETH"/>
 
     </LinearLayout>


### PR DESCRIPTION
now looks like this:

![screenshot_1520100810](https://user-images.githubusercontent.com/111600/36937804-299add96-1f19-11e8-80db-a827065085f6.png)

instead of:

![screenshot_1520101588](https://user-images.githubusercontent.com/111600/36937812-357959a8-1f19-11e8-8ba0-bed421290c72.png)

but in the end we should really limit decimals here : https://github.com/ethereum-lists/tokens/issues/31

cc @chrishobcroft 
