### PR TITLE
209/only show dialog when value imprecise

### DIFF
--- a/app/src/main/java/org/walleth/functions/Formatting.kt
+++ b/app/src/main/java/org/walleth/functions/Formatting.kt
@@ -32,3 +32,5 @@ fun BigDecimal.toFiatValueString() = twoDigitDecimalFormat.format(this)
         .adjustToMonetary2DecimalsWhenNeeded()
 
 fun String.addPrefixOnCondition(prefix: String, condition: Boolean) = if (condition) prefix + this else this
+
+fun CharSequence.isValueImprecise() = length > 0 && this[0] == '~'

--- a/app/src/main/java/org/walleth/ui/ValueView.kt
+++ b/app/src/main/java/org/walleth/ui/ValueView.kt
@@ -15,10 +15,7 @@ import org.walleth.data.config.Settings
 import org.walleth.data.exchangerate.ExchangeRateProvider
 import org.walleth.data.tokens.Token
 import org.walleth.data.tokens.isETH
-import org.walleth.functions.addPrefixOnCondition
-import org.walleth.functions.toFullValueString
-import org.walleth.functions.toValueString
-import org.walleth.functions.twoDigitDecimalFormat
+import org.walleth.functions.*
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.BigInteger.ZERO
@@ -40,13 +37,17 @@ open class ValueView(context: Context, attrs: AttributeSet) : LinearLayout(conte
         LayoutInflater.from(context).inflate(layoutRes, this, true)
         current_eth.setOnClickListener {
             currentToken?.let { tokenNotNull ->
-                showPreciseAmountAlert(currentValue.toFullValueString(tokenNotNull) + current_token_symbol.text)
+                if (current_eth.text.isValueImprecise()) {
+                    showPreciseAmountAlert(currentValue.toFullValueString(tokenNotNull) + current_token_symbol.text)
+                }
             }
         }
 
         current_fiat.setOnClickListener {
             currentExchangeValue?.let { currentExchangeValueNotNull ->
-                showPreciseAmountAlert(String.format("%f", currentExchangeValueNotNull) + current_fiat_symbol.text)
+                if (current_fiat.text.isValueImprecise()) {
+                    showPreciseAmountAlert(String.format("%f", currentExchangeValueNotNull) + current_fiat_symbol.text)
+                }
             }
         }
     }


### PR DESCRIPTION
Adding a simple CharSequence extension function to check if first character is '~' which indicates it was previous marked as imprecise in a format function and implemented it in the click listener on the ValueView.kt to fix #209 

Might integrate a test or two to prevent any regressions if the value format changes in the future / could expand it out to match against all non-numeric characters in the first position.