### PR TITLE
Reporting errors when relaying transactions fail

### DIFF
--- a/app/src/main/java/org/walleth/data/transactions/TransactionDAO.kt
+++ b/app/src/main/java/org/walleth/data/transactions/TransactionDAO.kt
@@ -52,7 +52,7 @@ interface TransactionDAO {
     @Query("SELECT nonce from transactions WHERE \"from\" = :address COLLATE NOCASE AND chain=:chain")
     fun getNonceForAddress(address: Address, chain: ChainDefinition): List<BigInteger>
 
-    @Query("SELECT * from transactions")
+    @Query("SELECT * from transactions WHERE r IS NOT NULL AND relayed=\"\" AND error IS NULL")
     fun getAllToRelayLive(): LiveData<List<TransactionEntity>>
 
     @Query("SELECT * from transactions WHERE hash = :hash COLLATE NOCASE")

--- a/app/src/online/java/org/walleth/dataprovider/DataProvidingService.kt
+++ b/app/src/online/java/org/walleth/dataprovider/DataProvidingService.kt
@@ -106,7 +106,7 @@ class DataProvidingService : LifecycleService() {
 
     private fun relayTransactionsIfNeeded() {
         appDatabase.transactions.getAllToRelayLive().nonNull().observe(this) { transactionList ->
-            transactionList.filter { it.signatureData != null && it.transactionState.relayed.isEmpty() }.forEach { sendTransaction(it) }
+            transactionList.forEach { sendTransaction(it) }
         }
     }
 

--- a/app/src/online/java/org/walleth/workers/RelayTransactionWorker.kt
+++ b/app/src/online/java/org/walleth/workers/RelayTransactionWorker.kt
@@ -47,8 +47,12 @@ class RelayTransactionWorker(appContext: Context, workerParams: WorkerParameters
                 if (result.error?.message != null) {
                     if (result.error?.message != "Transaction with the same hash was already imported.") {
                         // this error should not be surfaced to user
-                        transaction.transactionState.error = result.toString()
-                        return Result.retry()
+                        transaction.transactionState.error = result.error?.message;
+                        transaction.transactionState.eventLog = transaction.transactionState.eventLog ?: "" + "ERROR: ${result.error?.message}\n"
+
+                        appDatabase.transactions.upsert(transaction);
+
+                        return Result.failure();
                     }
                 } else {
                     val newHash = result.result


### PR DESCRIPTION
As followup of issue : https://github.com/walleth/walleth/issues/343
Change 1 : In RelayTransctionWorker : Added a the error to transctionState.errorLog  + added the missing upsert to save the modification of the transaction.
Change 2 : The upsert of change 1 will make LiveData propsoe the transaction again for relaying : I optimized the @Query in DAO to query only transactions that need to be relayed and modified DataProvidingService accordingly.
