### PR TITLE
Return TXHASH to the calling Activity when a transaction is created by Intent

### DIFF
--- a/app/src/main/java/org/walleth/activities/IntentHandlerActivity.kt
+++ b/app/src/main/java/org/walleth/activities/IntentHandlerActivity.kt
@@ -100,10 +100,9 @@ class IntentHandlerActivity : WallethActivity() {
 
     private fun process681(erC681: ERC681) {
         if (erC681.address == null || erC681.isTokenTransfer() || erC681.value != null && erC681.value != ZERO) {
-            startActivity(Intent(this, CreateTransactionActivity::class.java).apply {
+            startActivityForResult(Intent(this, CreateTransactionActivity::class.java).apply {
                 data = intent.data
-            })
-            finish()
+            }, CREATE_TX_REQUEST_CODE)
         } else {
             AlertDialog.Builder(this)
                     .setTitle(R.string.select_action_messagebox_title)

--- a/app/src/main/java/org/walleth/data/transactions/TransactionDAO.kt
+++ b/app/src/main/java/org/walleth/data/transactions/TransactionDAO.kt
@@ -52,7 +52,7 @@ interface TransactionDAO {
     @Query("SELECT nonce from transactions WHERE \"from\" = :address COLLATE NOCASE AND chain=:chain")
     fun getNonceForAddress(address: Address, chain: ChainDefinition): List<BigInteger>
 
-    @Query("SELECT * from transactions")
+    @Query("SELECT * from transactions WHERE r IS NOT NULL AND relayed=\"\" AND error IS NULL")
     fun getAllToRelayLive(): LiveData<List<TransactionEntity>>
 
     @Query("SELECT * from transactions WHERE hash = :hash COLLATE NOCASE")

--- a/app/src/online/java/org/walleth/dataprovider/DataProvidingService.kt
+++ b/app/src/online/java/org/walleth/dataprovider/DataProvidingService.kt
@@ -106,7 +106,7 @@ class DataProvidingService : LifecycleService() {
 
     private fun relayTransactionsIfNeeded() {
         appDatabase.transactions.getAllToRelayLive().nonNull().observe(this) { transactionList ->
-            transactionList.filter { it.signatureData != null && it.transactionState.relayed.isEmpty() }.forEach { sendTransaction(it) }
+            transactionList.forEach { sendTransaction(it) }
         }
     }
 

--- a/app/src/online/java/org/walleth/workers/RelayTransactionWorker.kt
+++ b/app/src/online/java/org/walleth/workers/RelayTransactionWorker.kt
@@ -47,8 +47,12 @@ class RelayTransactionWorker(appContext: Context, workerParams: WorkerParameters
                 if (result.error?.message != null) {
                     if (result.error?.message != "Transaction with the same hash was already imported.") {
                         // this error should not be surfaced to user
-                        transaction.transactionState.error = result.toString()
-                        return Result.retry()
+                        transaction.transactionState.error = result.error?.message;
+                        transaction.transactionState.eventLog = transaction.transactionState.eventLog ?: "" + "ERROR: ${result.error?.message}\n"
+
+                        appDatabase.transactions.upsert(transaction);
+
+                        return Result.failure();
                     }
                 } else {
                     val newHash = result.result


### PR DESCRIPTION
This contributes to https://github.com/walleth/walleth/issues/149

Currently starting a VIEW Intent on ERC681 URL opens WallETH to create the transaction, but calling native DApp needed the transaction hash to be able to verify and track the transaction. 

This was not always returned back by IntentHandlerActivity. Now it is fixed.