### PR TITLE
Update checksum-dependency to 1.28: fix compatibility with gradle-versions-plugin

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ include ':app'
 // It is a  plugin that verifies checksums of all the resolved files (plugins, dependencies, ...)
 buildscript {
   dependencies {
-    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.26.0') {
+    classpath('com.github.vlsi.gradle:checksum-dependency-plugin:1.28.0') {
       // Gradle ships kotlin-stdlib which is good enough
       exclude(group: "org.jetbrains.kotlin", module:"kotlin-stdlib")
     }
@@ -24,8 +24,8 @@ def expectedSha512 = [
     "okhttp-4.1.0.jar",
   "93E7A41BE44CC17FB500EA5CD84D515204C180AEC934491D11FC6A71DAEA761FB0EECEF865D6FD5C3D88AAF55DCE3C2C424BE5BA5D43BEBF48D05F1FA63FA8A7":
     "okio-2.2.2.jar",
-  "2AB28DC6026A9CFC869C6287501D1002B8F2B61C7C3896B61A5616CE686DD41FD22EE9FD2D122111E4DABAA8359A4947C3F43B9DF29B1AFC8AA5D809A8188CAD":
-    "checksum-dependency-plugin-1.26.0.jar"
+  "2ABC83FF0675D69697D4530D4853411761FE947E57EB8D68F6590DC2BFF0436906ADE619822EEE5F80B0DA28285FBE75FDCB50B67421DB7BF78B34CF6A613714":
+    "checksum-dependency-plugin-1.28.0.jar"
 ]
 
 def sha512(File file) {


### PR DESCRIPTION
see https://github.com/vlsi/vlsi-release-plugins/issues/18
